### PR TITLE
Lt5-072224

### DIFF
--- a/calculus/source/01-LT/05.ptx
+++ b/calculus/source/01-LT/05.ptx
@@ -80,7 +80,7 @@
 
       <remark>
         <statement>
-            <p>    We say that the function <m>1/x^3</m> has horizontal asymptote y=0 because the limit as <m>x</m> tends to positive infinity of <m>1/x^3</m> is 0. Alternatively, we could also justify it by saying that the limit as <m>x</m> goes to negative infinity is 0. </p>
+            <p>    We say that the function <m>1/x^3</m> has horizontal asymptote <m>y=0</m> because the limit as <m>x</m> tends to positive infinity of <m>1/x^3</m> is 0. Alternatively, we could also justify it by saying that the limit as <m>x</m> goes to negative infinity is 0. </p>
              </statement>
         </remark>
 


### PR DESCRIPTION
Fixes the math mode issue around y=0 in Remark 1.5.3