### PR TITLE
Missed a function

### DIFF
--- a/precalculus/exercises/outcomes/PR/PR6/template.xml
+++ b/precalculus/exercises/outcomes/PR/PR6/template.xml
@@ -55,7 +55,7 @@
     <knowl>
         <content>
             <p>
-                Find any horizontal asymptotes of <m>y=\displaystyle \frac{ {{num}} }{ {{denom}} }</m>.
+                Find any horizontal asymptotes of <m>y=f(x)</m>.
             </p>
         </content>
 


### PR DESCRIPTION
Missed a function when editing previously.  $f(x)$ is defined at the top, so to declutter this replaces it with $y=f(x)$ below.