### PR TITLE
Cg2wilson-DF-typos

### DIFF
--- a/calculus/source/02-DF/01.ptx
+++ b/calculus/source/02-DF/01.ptx
@@ -91,7 +91,7 @@
         <me> \frac{f(2+h)-f(2)}{(2+h)-2} = \frac{f(2+h)-f(2)}{h}.</me>
     </observation>
     
-    <observation><p>We want to be able to consider intervals before and after <m>t=2</m>. A positive value of <m>h</m> will give an interval after <m>t=2</m>. For example, the interval <m>[2,3]</m> for <m>h=1</m>. A negative value of <m>h</m> will give an interval before <m>t=2</m>. For example, the interval <m>[1,2]</m> corresponds <m>h=-1</m>. In the formula above, it looks like the interval would be <m>[2,1]</m>, but the standard notation in an interval is to write the smallest number first. This does not change the difference quotient because </p>
+    <observation><p>We want to be able to consider intervals before and after <m>t=2</m>. A positive value of <m>h</m> will give an interval after <m>t=2</m>. For example, the interval <m>[2,3]</m> corresponds to <m>h=1</m>. A negative value of <m>h</m> will give an interval before <m>t=2</m>. For example, the interval <m>[1,2]</m> corresponds to <m>h=-1</m>. In the formula above, it looks like the interval would be <m>[2,1]</m>, but the standard notation in an interval is to write the smallest number first. This does not change the difference quotient because </p>
        <me> \frac{f(2+h)-f(2)}{(2+h)-2} = \frac{f(2)-f(2+h)}{2-(2+h)}.</me>
     </observation>
     

--- a/calculus/source/02-DF/01.ptx
+++ b/calculus/source/02-DF/01.ptx
@@ -88,11 +88,11 @@
     </activity>
     
     <observation> <p> If we want to study the velocity at the instant <m>t=2</m>, it is helpful to study the average velocity on small intervals around <m>t=2</m>. If we consider the interval <m>[2,2+h]</m>, where <m>h</m> is the width of the interval, the average velocity is given by the difference quotient </p>
-        <me> \frac{f(2+h)-f(2)}{(2+h)-2} = \frac{f(2+h)-f(2)}{h}.</me>
+        <me> \dfrac{f(2+h)-f(2)}{(2+h)-2} = \dfrac{f(2+h)-f(2)}{h}.</me>
     </observation>
     
     <observation><p>We want to be able to consider intervals before and after <m>t=2</m>. A positive value of <m>h</m> will give an interval after <m>t=2</m>. For example, the interval <m>[2,3]</m> corresponds to <m>h=1</m>. A negative value of <m>h</m> will give an interval before <m>t=2</m>. For example, the interval <m>[1,2]</m> corresponds to <m>h=-1</m>. In the formula above, it looks like the interval would be <m>[2,1]</m>, but the standard notation in an interval is to write the smallest number first. This does not change the difference quotient because </p>
-       <me> \frac{f(2+h)-f(2)}{(2+h)-2} = \frac{f(2)-f(2+h)}{2-(2+h)}.</me>
+       <me> \dfrac{f(2+h)-f(2)}{(2+h)-2} = \dfrac{f(2)-f(2+h)}{2-(2+h)}.</me>
     </observation>
     
      <activity xml:id = "activity-ball2">
@@ -112,17 +112,17 @@
     </activity>
     
  <definition xml:id = "def-inst-vel"> 
-     <p> The instanteous velocity at <m>t=a</m> is the limit as <m>h \to 0</m> of the difference quotient <m>\frac{f(a+h)-f(a)}{h}</m>. In the activity above the instantaneous velocity at <m>t=2</m> is given by the limit
+     <p> The instanteous velocity at <m>t=a</m> is the limit as <m>h \to 0</m> of the difference quotient <m>\dfrac{f(a+h)-f(a)}{h}</m>. In the activity above the instantaneous velocity at <m>t=2</m> is given by the limit
      </p>
      <me>
-     v(2) = \lim_{h\to 0} \frac{f(2+h)-f(2)}{h}</me>    
+     v(2) = \lim_{h\to 0} \dfrac{f(2+h)-f(2)}{h}</me>    
   </definition>   
  
  <definition xml:id = "def-slope-secant"> 
      <p>
          The slope of the secant line to <m>f(x)</m> through the points <m>x=a</m> and <m>x=b</m> is given by the difference quotient 
          </p>
-    <me>\frac{f(b)-f(a)}{b-a}.</me>
+    <me>\dfrac{f(b)-f(a)}{b-a}.</me>
 </definition>
     
         <activity xml:id = "activity-der-graph1">
@@ -218,18 +218,18 @@
      <observation xml:id = "secant-to-tangent"> 
      <p>
          The slope of the secant line to <m>f(x)</m> through the points <m>x=a</m> and <m>x=b</m> is given by the difference quotient 
-    <m>\frac{f(b)-f(a)}{b-a}</m>. As the point <m>x=b</m> gets closer to <m>x=a</m>, the slope of the secant line tends to the slope of the tangent line. In symbols, the slope at <m>x=a</m> is given by the <em>limit</em></p>
-         <me> \lim_{x\to a} \frac{f(x)-f(a)}{x-a}.
+    <m>\dfrac{f(b)-f(a)}{b-a}</m>. As the point <m>x=b</m> gets closer to <m>x=a</m>, the slope of the secant line tends to the slope of the tangent line. In symbols, the slope at <m>x=a</m> is given by the <em>limit</em></p>
+         <me> \lim_{x\to a} \dfrac{f(x)-f(a)}{x-a}.
          </me>
          <p>
          Letting <m>b=a+h</m>, we can also say that the slope of the tangent line at <m>x=a</m> is given by the limit</p>
-    <me>\lim_{h\to 0} \frac{f(a+h)-f(a)}{h}.</me>
+    <me>\lim_{h\to 0} \dfrac{f(a+h)-f(a)}{h}.</me>
     </observation>
   
     <definition xml:id="def-derivative-point">
        <p> The derivative of <m>f(x)</m> at <m>x=a</m>, denoted <m>f'(a)</m>, is given by 
 </p>
-        <me>f'(a) = \lim_{h\to 0} \frac{f(a+h)-f(a)}{h}.</me>
+        <me>f'(a) = \lim_{h\to 0} \dfrac{f(a+h)-f(a)}{h}.</me>
     </definition>
     
       <observation> <p>In <xref ref ="activity-ball1" />  and <xref ref ="activity-ball2" /> you studied a ball falling under gravity and estimated the instantaneous velocity as a limiting value of average velocities on smaller and smaller intervals. Drawing the corresponding secant lines, we see how the secant lines approximate better the tangent line, showing graphically what we previouly saw numericaly. Here is a Desmos animation showing the secant lines approaching the tangent line  <url href = "https://www.desmos.com/calculator/bzs1bxz7fa"/>.  </p></observation>
@@ -241,12 +241,12 @@
                 <li><p> The value of the derivative of <m>f(x)</m> at <m>x=a</m> </p></li>
          <li><p> The slope of the tangent line to <m>f(x)</m> at <m>x=a</m> </p></li>
          <li><p> The instantaneous velocity of the object at <m>x=a</m> </p></li>
-         <li><p> The difference quotient <m>\frac{f(a+h)-f(a)}{h} </m> </p></li>
-         <li><p> The limit <m>\displaystyle\lim_{h \to 0} \frac{f(a+h)-f(a)}{h} </m> </p></li>                    
+         <li><p> The difference quotient <m>\dfrac{f(a+h)-f(a)}{h} </m> </p></li>
+         <li><p> The limit <m>\displaystyle\lim_{h \to 0} \dfrac{f(a+h)-f(a)}{h} </m> </p></li>                    
               </ol>    
                    </activity>
  
-    <observation xml:id = "estimating-der"> <p>We can use the difference quotient <m>\frac{f(a+h)-f(a)}{h} </m> for small values of <m>h</m> to <em>estimate</em> <m>f'(a)</m>, the value of the derivative at <m>x=a</m>. </p> </observation>
+    <observation xml:id = "estimating-der"> <p>We can use the difference quotient <m>\dfrac{f(a+h)-f(a)}{h} </m> for small values of <m>h</m> to <em>estimate</em> <m>f'(a)</m>, the value of the derivative at <m>x=a</m>. </p> </observation>
        
     <activity>
         <p>Suppose that you know that the function <m>g(x)</m> has values <m>g(-0.5)=7</m>, <m>g(0)=4</m>, and <m>g(0.5)=2</m>. What is your best estimate for <m>g'(0)?</m></p>
@@ -425,7 +425,7 @@ Defined and continuous on the interval <m>[-5,5]</m>.
                         </li>
                         <li>
                             <p>
-<m>\displaystyle\lim_{h\to 0} \frac{f( 2 +h)-f( 2 )}{h}&lt; 0</m>
+<m>\displaystyle\lim_{h\to 0} \dfrac{f( 2 +h)-f( 2 )}{h}&lt; 0</m>
                             </p>
                         </li>
                         <li>

--- a/calculus/source/02-DF/02.ptx
+++ b/calculus/source/02-DF/02.ptx
@@ -13,7 +13,7 @@
     <title>Activities</title>
    <observation xml:id="derivative-on-interval">
        <statement>
-      <p> Recall that <m>f'(a)</m>, the derivative of <m>f(x)</m> at <m>x=a</m>, was defined as the limit as <m>h \to 0</m> of the difference quotient on the interval <m>[a,a+h]</m> as in <xref ref="def-derivative-point"/>. If <m>f'(a)</m> exists, then say that <m>f(x)</m> is differentiable at <m>a</m>. If for some open interval <m>(a,b)</m>, we have that <m>f'(x)</m> exists for every point <m>x</m> in <m>(a,b)</m>, then we say that <m>f(x)</m> is differentiable on <m>(a,b)</m>. </p> </statement>
+      <p> Recall that <m>f'(a)</m>, the derivative of <m>f(x)</m> at <m>x=a</m>, was defined as the limit as <m>h \to 0</m> of the difference quotient on the interval <m>[a,a+h]</m> as in <xref ref="def-derivative-point"/>. If <m>f'(a)</m> exists, then we say that <m>f(x)</m> is differentiable at <m>a</m>. If for some open interval <m>(a,b)</m>, we have that <m>f'(x)</m> exists for every point <m>x</m> in <m>(a,b)</m>, then we say that <m>f(x)</m> is differentiable on <m>(a,b)</m>. </p> </statement>
     </observation>
 
     <activity xml:id="activity-derivative-analytically-point">

--- a/calculus/source/02-DF/02.ptx
+++ b/calculus/source/02-DF/02.ptx
@@ -61,7 +61,7 @@
         <p> The last type of notation is known as <em>differential</em> (or Leibniz) notation for the derivative.</p></remark>
     
    <remark xml:id="derivative-notation2"> 
-    <p>Notice that our notation for the derivative function is based on the name that we assign to the function along with our choice of notation for indendent and dependent variables.  For example, if we have a differentiable function <m>y=v(t)</m>, the derivative function of <m>v(t)</m> with respect to <m>t</m> can be written as <m>v'(t)=y'(t)=\frac{dy}{dt}=\frac{dv}{dt}</m>.</p>
+    <p>Notice that our notation for the derivative function is based on the name that we assign to the function along with our choice of notation for indendent and dependent variables.  For example, if we have a differentiable function <m>y=v(t)</m>, the derivative function of <m>v(t)</m> with respect to <m>t</m> can be written as <m>v'(t)=y'(t)=\dfrac{dy}{dt}=\dfrac{dv}{dt}</m>.</p>
     </remark>
     
     <activity xml:id="activity-derivative-analytically-algebraic1">
@@ -190,7 +190,7 @@ The second derivative is the derivative of the derivative. It encodes informatio
     
       <activity xml:id="activity-derivative-analytically-algebraic4">
           <introduction>
-            <p> Consider the function <m>f(x) = \frac{1}{x^2}</m>. You will find <m>f'(1)</m> in two ways!  </p>   </introduction>
+            <p> Consider the function <m>f(x) = \dfrac{1}{x^2}</m>. You will find <m>f'(1)</m> in two ways!  </p>   </introduction>
                  <task> <p> Using the limit definition of the derivative at a point, compute the difference quotient on the interval <m>[1,1+h]</m> and then take the limit as <m>h\to 0</m>. What do you get? </p> 
              <ol marker="A." cols="2">
                 <li><p> -1 </p></li>

--- a/calculus/source/02-DF/03.ptx
+++ b/calculus/source/02-DF/03.ptx
@@ -76,7 +76,7 @@
     
     <observation xml:id="obs-derivative-notation3">
         <p>
-    We have been using <m>f'(x)</m>, read <q><m>f</m> prime</q>, to denote a derivative of the function <m>f(x)</m>.  There are other ways to denote the derivative of <m>y=f(x)</m>: <m>y'</m> or <m>\frac{df}{dx}</m>, pronounced <q>dee-f dee-x</q>.  If you want to take the derivative of <m>f'(x)</m>, <m>y'</m>, or <m>\frac{df}{dx}</m> to get the second derivative of <m>f(x)</m>, the notation is <m>f''(x)</m>, <m>y''</m>, or <m>\frac{d^2f}{dx^2}</m>. </p>
+    We have been using <m>f'(x)</m>, read <q><m>f</m> prime</q>, to denote a derivative of the function <m>f(x)</m>.  There are other ways to denote the derivative of <m>y=f(x)</m>: <m>y'</m> or <m>\dfrac{df}{dx}</m>, pronounced <q>dee-f dee-x</q>.  If you want to take the derivative of <m>f'(x)</m>, <m>y'</m>, or <m>\dfrac{df}{dx}</m> to get the second derivative of <m>f(x)</m>, the notation is <m>f''(x)</m>, <m>y''</m>, or <m>\dfrac{d^2f}{dx^2}</m>. </p>
     </observation>
     
     <activity xml:id="activity-derivative-elementary2">
@@ -140,7 +140,7 @@
         </statement>
     </activity>
     
-    <activity xml:id="neg-fract-powers"><introduction><p>We can look at power functions with fractional exponents like <m>f(x)= x^{\frac{1}{4}}=\sqrt[4]{x}</m> or  with negative exponents like <m>g(x)= x^{-4} = \frac{1}{x^4}</m>. What is the derivative of these two functions?</p></introduction>
+    <activity xml:id="neg-fract-powers"><introduction><p>We can look at power functions with fractional exponents like <m>f(x)= x^{\frac{1}{4}}=\sqrt[4]{x}</m> or  with negative exponents like <m>g(x)= x^{-4} = \dfrac{1}{x^4}</m>. What is the derivative of these two functions?</p></introduction>
      <ol marker="A." cols="2">
                 <li><m>f'(x) = \frac{1}{4 \sqrt[4]{x^3}}, \, g'(x) = \frac{-4}{x^3}.</m></li>
                  <li><m>f'(x) = \frac{1}{4} \sqrt[4]{x^3}, \, g'(x) = \frac{-4}{x^5}.</m></li>
@@ -200,10 +200,10 @@ While <m>\log</m> is sometimes used to denote the <q>common logarithm</q> base <
     <statement>
         <p> Which of the following statements is NOT true?</p>
         <ol marker="A." cols="2">
-                <li>The derivative of <m>y = 2\ln(x)</m> is <m>y' = \frac{2}{x}.</m></li>
-                <li>The derivative of <m>y = \frac{\ln(x)}{2}</m> is <m>y' = \frac{1}{2x}.</m></li>
-                <li>The derivative of <m>y = \frac{2}{3}\ln(x)</m> is <m>y' = \frac{3}{2x}.</m></li>
-                <li>The derivative of <m>y = \ln(x^{2})</m> is <m>y' = \frac{2}{x}</m>.</li>
+                <li>The derivative of <m>y = 2\ln(x)</m> is <m>y' = \dfrac{2}{x}.</m></li>
+                <li>The derivative of <m>y = \dfrac{\ln(x)}{2}</m> is <m>y' = \dfrac{1}{2x}.</m></li>
+                <li>The derivative of <m>y = \dfrac{2}{3}\ln(x)</m> is <m>y' = \dfrac{3}{2x}.</m></li>
+                <li>The derivative of <m>y = \ln(x^{2})</m> is <m>y' = \dfrac{2}{x}</m>.</li>
         </ol>
         </statement>
     </activity>

--- a/calculus/source/02-DF/04.ptx
+++ b/calculus/source/02-DF/04.ptx
@@ -100,7 +100,7 @@
 
       <task>
         <p>
-           Let <m>Q(t) = \frac{t^3 + 4t}{2t^2}</m> and observe that <m>Q(t) = \frac{g(t)}{f(t)}</m>.
+           Let <m>Q(t) = \dfrac{t^3 + 4t}{2t^2}</m> and observe that <m>Q(t) = \dfrac{g(t)}{f(t)}</m>.
           Rewrite the formula for <m>Q</m> by dividing each term in the numerator by the denominator and use rules of exponents to write <m>Q</m> as a sum of scalar multiples of power functions.
           Then,
           compute <m>Q'(t)</m> using the sum and scalar multiple rules.
@@ -109,7 +109,7 @@
 
       <task>
         <p>
-          True or false: <m>Q'(t) = \frac{g'(t)}{f'(t)}</m>.
+          True or false: <m>Q'(t) = \dfrac{g'(t)}{f'(t)}</m>.
         </p>
       </task>
 </activity>
@@ -119,9 +119,9 @@
       <p>
            
        If <m>f</m> and <m>g</m> are differentiable functions,
-        then their quotient <m>Q(x) = \frac{f(x)}{g(x)}</m> is also a differentiable function for all <m>x</m> where <m>g(x) \ne 0</m> and
+        then their quotient <m>Q(x) = \dfrac{f(x)}{g(x)}</m> is also a differentiable function for all <m>x</m> where <m>g(x) \ne 0</m> and
         <me>
-          Q'(x) = \frac{ f'(x) \cdot g(x) -  f(x) \cdot g'(x)}{g(x)^2}
+          Q'(x) = \dfrac{ f'(x) \cdot g(x) -  f(x) \cdot g'(x)}{g(x)^2}
         </me>.
       </p>
     
@@ -139,10 +139,10 @@
         
            
             <ol marker="A." cols="2">
-                <li><m>f(x) = \frac{6}{x^3}</m></li>
-                <li><m>f(x) = \frac{2}{\ln x}</m></li>
-                <li><m>f(x) = \frac{e^x}{\sin x}</m></li>
-                <li><m>f(x) = \frac{x^3+3x}{x}</m></li>
+                <li><m>f(x) = \dfrac{6}{x^3}</m></li>
+                <li><m>f(x) = \dfrac{2}{\ln x}</m></li>
+                <li><m>f(x) = \dfrac{e^x}{\sin x}</m></li>
+                <li><m>f(x) = \dfrac{x^3+3x}{x}</m></li>
                 
             </ol>
     </activity>    
@@ -154,10 +154,10 @@
 
             </p>
         </introduction>
-       <task><m>f(x) = \frac{6}{x^3}</m></task>
-                <task><m>f(x) = \frac{2}{\ln x}</m></task>
-                <task><m>f(x) = \frac{e^x}{\sin x}</m></task>
-                <task><m>f(x) = \frac{x^3+3x}{x}</m></task>
+       <task><m>f(x) = \dfrac{6}{x^3}</m></task>
+                <task><m>f(x) = \dfrac{2}{\ln x}</m></task>
+                <task><m>f(x) = \dfrac{e^x}{\sin x}</m></task>
+                <task><m>f(x) = \dfrac{x^3+3x}{x}</m></task>
      
     </activity>
     
@@ -167,8 +167,8 @@
             Be sure to explicitly denote which derivative rules (product, quotient, sum and difference, etc.) you are using in your work.
             </p></introduction>
         
-            <task><me>f(w)= -\frac{3 \, w^{2} + 5 \, w - 2}{\sin\left(w\right)}</me></task>
-            <task><me>g(t)= \frac{t^{2} + 6 \, t + 1}{t^{2}}</me></task>
+            <task><me>f(w)= -\dfrac{3 \, w^{2} + 5 \, w - 2}{\sin\left(w\right)}</me></task>
+            <task><me>g(t)= \dfrac{t^{2} + 6 \, t + 1}{t^{2}}</me></task>
             <task><me>h(t)= -2 \, {\left(t^{2} + 3 \, t + 3\right)} \cos\left(t\right)</me></task>
         
  <!--   <answer>
@@ -195,7 +195,7 @@
         <introduction>
             <p>
                Consider the function <m>f(x) = \tan x </m>, and remember that
-    <m>\tan x  = \frac{\sin x}{\cos x}</m>.
+    <m>\tan x  = \dfrac{\sin x}{\cos x}</m>.
 
 
             </p>
@@ -203,11 +203,11 @@
      <task> <p> What is the domain of <m>f</m>?</p></task>
      <task> <p>  Use the quotient rule to show that one expression for <m>f'(x)</m> is
           <me>
-            f'(x) = \frac{(\cos x)(\cos x) + (\sin x)(\sin x)}{(\cos x)^2}
+            f'(x) = \dfrac{(\cos x)(\cos x) + (\sin x)(\sin x)}{(\cos x)^2}
           </me>.</p> </task>
      <task><p>Which trig identity might be useful here to simplify this expression?
           How can this identity be used to find a simpler form for <m>f'(x)</m>?</p></task>
-     <task><p> Recall that <m>\sec x = \frac{1}{\cos x}</m>.
+     <task><p> Recall that <m>\sec x = \dfrac{1}{\cos x}</m>.
           How can we express <m>f'(x)</m> in terms of the secant function?</p></task>
      <task><p>  For what values of <m>x</m> is <m>f'(x)</m> defined?
           How does this domain compare to the domain of <m>f</m>?</p></task>
@@ -217,7 +217,7 @@
     <activity xml:id="activity-df-quotient-rule-cotx">
         <introduction>
             <p> Let <m>g(x) = \cot x </m>, and recall that
-    <m>\cot  x  = \frac{\cos x }{\sin x }</m>.
+    <m>\cot  x  = \dfrac{\cos x }{\sin x }</m>.
 
 
             </p>
@@ -234,7 +234,7 @@
     <activity xml:id="activity-df-quotient-rule-secx">
         <introduction>
             <p> Let <m>h(x) = \sec x </m>, and recall that
-    <m>\sec x  = \frac{1}{\cos x }</m>.
+    <m>\sec x  = \dfrac{1}{\cos x }</m>.
 
 
             </p>
@@ -251,7 +251,7 @@
     <activity xml:id="activity-df-quotient-rule-cscx">
         <introduction>
             <p> Let <m>p(x) = \csc x </m>, and recall that
-    <m>\csc x  = \frac{1}{\sin x }</m>.
+    <m>\csc x  = \dfrac{1}{\sin x }</m>.
 
 
             </p>
@@ -267,12 +267,12 @@
     
 <theorem xml:id="thm-df-other-trig-rules"> <p> We can now summarize the derivatives of all six trigonometric functions.</p>
     <ul>
-        <li><m>\frac{d}{dx} \sin x = \cos x</m></li>
-        <li><m>\frac{d}{dx} \cos x = -\sin x</m></li>
-        <li><m>\frac{d}{dx} \tan x = (\sec x)^2</m></li>
-        <li><m>\frac{d}{dx} \cot x = -(\csc x)^2</m></li>
-        <li><m>\frac{d}{dx} \sec x = \sec x \tan x </m></li>
-        <li><m>\frac{d}{dx} \csc x = -\csc x \cot x </m></li>
+        <li><m>\dfrac{d}{dx} \sin x = \cos x</m></li>
+        <li><m>\dfrac{d}{dx} \cos x = -\sin x</m></li>
+        <li><m>\dfrac{d}{dx} \tan x = (\sec x)^2</m></li>
+        <li><m>\dfrac{d}{dx} \cot x = -(\csc x)^2</m></li>
+        <li><m>\dfrac{d}{dx} \sec x = \sec x \tan x </m></li>
+        <li><m>\dfrac{d}{dx} \csc x = -\csc x \cot x </m></li>
     </ul>
     </theorem>
     

--- a/calculus/source/02-DF/05.ptx
+++ b/calculus/source/02-DF/05.ptx
@@ -48,7 +48,7 @@
       <p>  My neighborhood is being invaded! The squirrel population grows based on acorn availability, at a rate of 2 squirrels per bushel of acorns.  Acorn availability grows at a rate of 100 bushels of acorns per week. How fast is the squirrel population growing per week? </p>
       </introduction>
            <task>
-        <p> The scenario gives you information regarding the rate of growth of <m>s(a)</m>, the squirrel population as a function of acorn availability (measured in bushels). What is the current value of <m>\frac{ds}{da}</m>? </p>
+        <p> The scenario gives you information regarding the rate of growth of <m>s(a)</m>, the squirrel population as a function of acorn availability (measured in bushels). What is the current value of <m>\dfrac{ds}{da}</m>? </p>
            <ol marker="A." cols="2">
                 <li><p> 2 </p></li>
                  <li><p>100  </p></li>
@@ -57,7 +57,7 @@
               </ol>
                </task>
         <task>
-        <p> The scenario gives you information regarding the rate of growth of <m>a(t)</m>, the acorn availability as a function of time (measured in weeks). What is the current value of <m>\frac{da}{dt}</m>? </p>
+        <p> The scenario gives you information regarding the rate of growth of <m>a(t)</m>, the acorn availability as a function of time (measured in weeks). What is the current value of <m>\dfrac{da}{dt}</m>? </p>
            <ol marker="A." cols="2">
                 <li><p> 2 </p></li>
                  <li><p>100  </p></li>
@@ -66,7 +66,7 @@
               </ol>
                </task>
        <task>
-        <p> Given all the information provided, what is your best guess for the value of  <m>\frac{ds}{dt}</m>, the rate at which the squirrel population is growing per week? </p>
+        <p> Given all the information provided, what is your best guess for the value of  <m>\dfrac{ds}{dt}</m>, the rate at which the squirrel population is growing per week? </p>
            <ol marker="A." cols="2">
                 <li><p> 2 </p></li>
                  <li><p>100  </p></li>
@@ -75,7 +75,7 @@
               </ol>
                </task>
              <task>
-        <p> Given your answers above, what is the relationship between <m>\frac{ds}{da}, \frac{da}{dt}, \frac{ds}{dt}</m>? </p>
+        <p> Given your answers above, what is the relationship between <m>\dfrac{ds}{da}, \dfrac{da}{dt}, \dfrac{ds}{dt}</m>? </p>
                </task>
                    </activity>
 
@@ -84,14 +84,14 @@
     <title>Chain Rule</title>
     <p>
         When looking at the composite function <m>f(g(x))</m>, we have that
-        <me>\frac{d}{dx}\Big(f( g(x) )\Big)= f'(g(x)) \cdot g'(x). </me>
+        <me>\dfrac{d}{dx}\Big(f( g(x) )\Big)= f'(g(x)) \cdot g'(x). </me>
         Using differential notation, if we consider the composite function <m>(v \circ u)(x)</m>, we have that
-        <me>\frac{dv}{dx}= \frac{dv}{du} \cdot \frac{du}{dx} </me>.
+        <me>\dfrac{dv}{dx}= \dfrac{dv}{du} \cdot \dfrac{du}{dx} </me>.
         This is known as the <term>chain rule</term><idx>chain rule</idx>.
     </p>
 </theorem>
 
-    <warning xml:id="chain-rule-warning"> <p> It is important to consider the input of a function when taking the derivative! In fact, <m>f'(g(x))</m>  and <m>f'(x)</m> are different functions... So computing <m>  \frac{dv}{dx} </m> gives a different result than computing <m>  \frac{dv}{du} </m>. </p></warning>
+    <warning xml:id="chain-rule-warning"> <p> It is important to consider the input of a function when taking the derivative! In fact, <m>f'(g(x))</m>  and <m>f'(x)</m> are different functions... So computing <m>  \dfrac{dv}{dx} </m> gives a different result than computing <m>  \dfrac{dv}{du} </m>. </p></warning>
 
     <activity xml:id="activity-chain-rule-warning">
            <task>
@@ -272,11 +272,11 @@
 = 2\left(50\sin(2t)+60\right)+10. </me>
           </introduction>
            <task>
-        <p> Check that the model satisfies the data <m>\frac{ds}{da}=2</m> and <m>\frac{da}{dt}\big|_{t=0} = 100 </m></p>
+        <p> Check that the model satisfies the data <m>\dfrac{ds}{da}=2</m> and <m>\dfrac{da}{dt}\big|_{t=0} = 100 </m></p>
 
                </task>
            <task>
-        <p> Find the derivative function <m>\frac{ds}{dt}</m> and check that <m>\frac{ds}{dt}|_{t=0} = 200</m>.  </p>
+        <p> Find the derivative function <m>\dfrac{ds}{dt}</m> and check that <m>\dfrac{ds}{dt}|_{t=0} = 200</m>.  </p>
                </task>
        <task>
         <p> According to this model, what is the maximum and minimum squirrel population? What is the fastest rate of increase and decrease of the squirrel population? When will these extremal scenarions occur?</p>

--- a/calculus/source/02-DF/06.ptx
+++ b/calculus/source/02-DF/06.ptx
@@ -83,7 +83,7 @@
     
  <activity xml:id="activity-df-strat2">
  <introduction>
-  <p> Consider the function <m>f(x)= \left(\frac{\ln x}{(3x-4)^3} \right)^5</m>.</p>
+  <p> Consider the function <m>f(x)= \left(\dfrac{\ln x}{(3x-4)^3} \right)^5</m>.</p>
    
 </introduction> 
    <task><p>
@@ -146,7 +146,7 @@
     
  <activity xml:id="activity-df-strat4">
  <introduction>
-  <p> Consider the function <m>f(x)= \frac{x^2 e^x}{2x^3-5x+\sqrt{x}}</m>.</p>
+  <p> Consider the function <m>f(x)= \dfrac{x^2 e^x}{2x^3-5x+\sqrt{x}}</m>.</p>
    
 </introduction> 
    <task><p>
@@ -182,7 +182,7 @@
    
 </introduction> 
    <task> <m> f(x) = e^{5x}(x^2+7^x)^3</m></task>        
-   <task> <m> f(x) = \left( \frac{3x + 1}{2x^{6} - 1} \right)^{ 5 } </m></task>
+   <task> <m> f(x) = \left( \dfrac{3x + 1}{2x^{6} - 1} \right)^{ 5 } </m></task>
    <task> <m> f(x) = \sqrt{\cos\left(2 \, x^{2} + x\right)}</m></task>    
    <task> <m> f(x) = \tan(xe^x)</m></task>       
 

--- a/calculus/source/02-DF/07.ptx
+++ b/calculus/source/02-DF/07.ptx
@@ -32,21 +32,21 @@
       <statement>
           <p>The derivative with respect to <m>x</m> for the equation of the circle is given by which expression.</p>
           <ol marker="A." cols="2">
-                <li><p><m>2x + 2y\frac{dy}{dx} = 25</m></p></li>
-                <li><p><m>2x + y\frac{dy}{dx} = 0</m></p></li>
-                <li><p><m>2x + 2y\frac{dy}{dx} = 0</m></p></li>
-                <li><p><m>2x + 2\frac{dy}{dx} = 25</m></p></li>
+                <li><p><m>2x + 2y\dfrac{dy}{dx} = 25</m></p></li>
+                <li><p><m>2x + y\dfrac{dy}{dx} = 0</m></p></li>
+                <li><p><m>2x + 2y\dfrac{dy}{dx} = 0</m></p></li>
+                <li><p><m>2x + 2\dfrac{dy}{dx} = 25</m></p></li>
             </ol>
           </statement>
       </task>
       <task>
       <statement>
-          <p>Solving for <m>\frac{dy}{dx}</m> gives?</p>
+          <p>Solving for <m>\dfrac{dy}{dx}</m> gives?</p>
           <ol marker="A." cols="2">
-                <li><p><m>\frac{dy}{dx} = \frac{25-2x}{2y}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = -\frac{2x}{y}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = -\frac{x}{y}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{25-2x}{2}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{25-2x}{2y}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = -\dfrac{2x}{y}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = -\dfrac{x}{y}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{25-2x}{2}</m></p></li>
             </ol>
           </statement>
       </task>
@@ -63,7 +63,7 @@
 
     <activity xml:id="activity-derivative-implicit2">
     <introduction>
-        <p>The curve given in <xref ref = "figure-derivative-implicit2"/> is an example of an astroid.  The equation of this astroid is <m>x^{2/3} + y^{2/3} = 3^{2/3}</m>.  What is the derivative with respect <m>x</m> for this astroid? (Solve for <m>\frac{dy}{dx}</m>).</p>
+        <p>The curve given in <xref ref = "figure-derivative-implicit2"/> is an example of an astroid.  The equation of this astroid is <m>x^{2/3} + y^{2/3} = 3^{2/3}</m>.  What is the derivative with respect <m>x</m> for this astroid? (Solve for <m>\dfrac{dy}{dx}</m>).</p>
         </introduction>
          <figure xml:id="figure-derivative-implicit2">
        <image width="70%" source="derivative_implicit2_graph.png" />
@@ -79,7 +79,7 @@
     
     <activity xml:id="activity-derivative-implicit3">
     <introduction>
-        <p>An example of a lemniscate is given in <xref ref = "figure-derivative-implicit3"/>.  The equation of this lemniscate is <m>(x^{2} + y^{2})^2 = x^2 - y^2</m>.  What is the derivative with respect <m>x</m> for this lemniscate? (Solve for <m>\frac{dy}{dx}</m>).</p>
+        <p>An example of a lemniscate is given in <xref ref = "figure-derivative-implicit3"/>.  The equation of this lemniscate is <m>(x^{2} + y^{2})^2 = x^2 - y^2</m>.  What is the derivative with respect <m>x</m> for this lemniscate? (Solve for <m>\dfrac{dy}{dx}</m>).</p>
         </introduction>
          <figure xml:id="figure-derivative-implicit3">
        <image width="70%" source="derivative_implicit3_graph.png" />
@@ -97,7 +97,7 @@
     <introduction>
         <p>
 Explain how to use implicit differentiation to find
-<m>\frac{dy}{dx}</m> for each of the following equations.
+<m>\dfrac{dy}{dx}</m> for each of the following equations.
         </p></introduction>
         
                 <task><p><me>-5 \, x^{5} - 5 \, \cos\left(y\right) = 3 \, y^{4} + 2</me></p></task>
@@ -113,13 +113,13 @@ Explain how to use implicit differentiation to find
 </activity>
     <activity xml:id="activity-derivative-implicit4">
     <introduction>
-        <p>To take the derivative of some explicit equations you might need to make it an implicit equation.  For this activity we will find the derivative of <m>y = x^x</m>.  Make the equation an implicit equation by taking natural logarithm of both sides, this gives <m>\ln(y) = x\ln(x)</m>. Knowing this, what is <m>\frac{dy}{dx}</m>? This process to find a derivative is known as logarithmic differentiation. </p>
+        <p>To take the derivative of some explicit equations you might need to make it an implicit equation.  For this activity we will find the derivative of <m>y = x^x</m>.  Make the equation an implicit equation by taking natural logarithm of both sides, this gives <m>\ln(y) = x\ln(x)</m>. Knowing this, what is <m>\dfrac{dy}{dx}</m>? This process to find a derivative is known as logarithmic differentiation. </p>
         </introduction>
          <ol marker="A." cols="2">
-                <li><p><m>\frac{dy}{dx} = x^x(\ln(x) + 1)</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{(\ln(x)+1)}{x^x}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = x^x(\ln(x) + x)</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{(\ln(x)+x)}{x^x}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = x^x(\ln(x) + 1)</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{(\ln(x)+1)}{x^x}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = x^x(\ln(x) + x)</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{(\ln(x)+x)}{x^x}</m></p></li>
             </ol>
      </activity> 
     

--- a/calculus/source/02-DF/08.ptx
+++ b/calculus/source/02-DF/08.ptx
@@ -32,7 +32,7 @@
                 <li><p><m>\frac{dy}{dx} = \frac{1}{e^y}</m></p></li>
             </ol>
     </task>
-    <task><p>Notice that we started with the relationship <m>e^y=x</m>. Use this to simplify <m>\frac{dy}{dx}</m>. You should get that when <m>y=\ln(x)</m> we have that <m>\frac{dy}{dx} = \frac{1}{x}</m>... as expected!</p></task>
+    <task><p>Notice that we started with the relationship <m>e^y=x</m>. Use this to simplify <m>\dfrac{dy}{dx}</m>. You should get that when <m>y=\ln(x)</m> we have that <m>\dfrac{dy}{dx} = \dfrac{1}{x}</m>... as expected!</p></task>
     </activity>
 
 <activity xml:id="activity-df-inv-general">
@@ -123,7 +123,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
                     <caption>The graphs of <m> f(x)</m> and <m> f'(x)</m>.</caption>
                 </figure>                  
        </introduction>
-    <task><p>The derivative of the inverse function at <m>x=12</m> given by <m>(f^{-1})' (12) = \frac{1}{f'(f^{-1}(12))}</m>. Using the graphs, what is your best approximation for this quantity?</p>
+    <task><p>The derivative of the inverse function at <m>x=12</m> given by <m>(f^{-1})' (12) = \dfrac{1}{f'(f^{-1}(12))}</m>. Using the graphs, what is your best approximation for this quantity?</p>
       <ol marker="A." cols="2">
                 <li><p>  <m>(f^{-1})' (12)\approx \frac{1}{0.2} = 5 </m> </p></li>
                  <li><p>  <m>(f^{-1})' (12) \approx \frac{1}{0.6} \approx 1.67 </m> </p></li>
@@ -144,7 +144,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
 
 <activity xml:id="activity-df-inv2"> <introduction><p>Use the general formula for the derivative of the inverse function from <xref ref ="rmk-df-inv-general"/>  to find...</p></introduction>
     <task><p>The derivative of the inverse function of <m>f(x) = e^x</m>... This should match the result of <xref ref ="activity-df-inv-ln"/>!</p></task>
-      <task><p>The derivative of the inverse function of <m>f(x) = \frac{1}{x}</m>... This should match a derative that you have seen before! See if you can explain why.</p></task>
+      <task><p>The derivative of the inverse function of <m>f(x) = \dfrac{1}{x}</m>... This should match a derative that you have seen before! See if you can explain why.</p></task>
     </activity>
 
 
@@ -240,19 +240,19 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
 
 <activity>
     <introduction><p>In this activity you will find a formula for the derivative of arctangent.</p></introduction>
-    <task><p>Differentiate the implicit equation <m> \tan(y) = x</m>, what do you get for <m>\frac{dy}{dx}</m>?</p>
+    <task><p>Differentiate the implicit equation <m> \tan(y) = x</m>, what do you get for <m>\dfrac{dy}{dx}</m>?</p>
      <ol marker="A." cols="2">
-                <li><p><m>\frac{dy}{dx} = \frac{x}{\tan(y)}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{1}{\tan(y)}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{x}{\sec^2(y)}</m></p></li>
-                <li><p><m>\frac{dy}{dx} = \frac{1}{\sec^2(y)}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{x}{\tan(y)}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{1}{\tan(y)}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{x}{\sec^2(y)}</m></p></li>
+                <li><p><m>\dfrac{dy}{dx} = \dfrac{1}{\sec^2(y)}</m></p></li>
             </ol>
     </task>
     <task>
-    <p>For what function <m>y=g(x)</m> have you found the derivative <m>\frac{dy}{dx}</m>?</p>
+    <p>For what function <m>y=g(x)</m> have you found the derivative <m>\dfrac{dy}{dx}</m>?</p>
     </task>
-    <task><p>We want to rewrite <m>\frac{dy}{dx}</m> only in terms of <m>x</m>. Notice that </p>
-    <me> \tan^2(y) = \frac{\sin^2(y)}{\cos^2(y)} = \frac{1 - \cos^2(y)}{\cos^2(y)}. </me>
+    <task><p>We want to rewrite <m>\dfrac{dy}{dx}</m> only in terms of <m>x</m>. Notice that </p>
+    <me> \tan^2(y) = \dfrac{\sin^2(y)}{\cos^2(y)} = \dfrac{1 - \cos^2(y)}{\cos^2(y)}. </me>
       <p> Multiplying out by the denominator, isolating, and solving for <m>\cos^2(y)</m>, we get that </p>
          <ol marker="A." cols="2">
                 <li><p><m>\cos^2(y) = \frac{\tan^2(y)}{\cos^2(y)}</m></p></li>
@@ -261,16 +261,16 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
               <li><p><m>\cos^2(y) = \frac{1}{\tan^2(y) -1 }</m></p></li>
             </ol>
     </task>
-    <task><p>Finally, rewrite <m>\frac{dy}{dx}</m> as <m>\frac{dy}{dx} = \cos^2(y)</m> and use the fact that <m>\tan(y)=x</m> to get a nice formula for the derivative of the arctangent function of <m>x</m>.</p></task>
+    <task><p>Finally, rewrite <m>\dfrac{dy}{dx}</m> as <m>\dfrac{dy}{dx} = \cos^2(y)</m> and use the fact that <m>\tan(y)=x</m> to get a nice formula for the derivative of the arctangent function of <m>x</m>.</p></task>
     </activity>
 
 
 
 <remark><p> 
     Consider the functions <m>y = \tan^{-1}(x)</m>. Using your algebra above, you should have found that</p>
-<me>\frac{d}{dx}\Big(\tan^{-1}(x)\Big)=\frac{1}{1+x^2}.</me>
+<me>\dfrac{d}{dx}\Big(\tan^{-1}(x)\Big)=\dfrac{1}{1+x^2}.</me>
 <p>In a similar fashion, one can find that </p>
-    <me>\frac{d}{dx}\Big(\sin^{-1}(x)\Big)=\frac{1}{\sqrt{1-x^2}}, \quad \frac{d}{dx}\Big(\cos^{-1}(x)\Big)= - \frac{1}{\sqrt{1-x^2}}.</me>
+    <me>\dfrac{d}{dx}\Big(\sin^{-1}(x)\Big)=\dfrac{1}{\sqrt{1-x^2}}, \quad \dfrac{d}{dx}\Big(\cos^{-1}(x)\Big)= - \dfrac{1}{\sqrt{1-x^2}}.</me>
     </remark>
 
 
@@ -282,7 +282,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
             Be sure to explicitly denote which derivative rules (product, quotient, sum and difference, etc.) you are using in your work.
         </p>
         <ol marker="(a)">
-            <li><me>k(t)= \frac{\arctan\left(-4 \, t\right)}{\ln\left(-4 \, t\right)}</me></li>
+            <li><me>k(t)= \dfrac{\arctan\left(-4 \, t\right)}{\ln\left(-4 \, t\right)}</me></li>
             <li><me>j(u)= -5 \, \arcsin\left(u\right) \log\left(u^{6} + 2\right)</me></li>
             <li><me>n(x)= \ln\left(-\arcsin\left(x\right) + 4 \, \arctan\left(x\right)\right)</me></li>
         </ol>

--- a/calculus/source/main.ptx
+++ b/calculus/source/main.ptx
@@ -13,7 +13,7 @@
     <xi:include href="01-LT/main.ptx" />
 
     <xi:include href="02-DF/main.ptx" />
-    <!--
+    
     <xi:include href="03-AD/main.ptx" />
 
     <xi:include href="04-IN/main.ptx" />
@@ -27,7 +27,7 @@
     <xi:include href="08-SQ/main.ptx" />
 
     <xi:include href="09-PS/main.ptx" />
-  -->
+  
     <xi:include href="meta/backmatter.ptx" />
   </book>
 </pretext>

--- a/calculus/source/main.ptx
+++ b/calculus/source/main.ptx
@@ -13,7 +13,7 @@
     <xi:include href="01-LT/main.ptx" />
 
     <xi:include href="02-DF/main.ptx" />
-
+    <!--
     <xi:include href="03-AD/main.ptx" />
 
     <xi:include href="04-IN/main.ptx" />
@@ -27,7 +27,7 @@
     <xi:include href="08-SQ/main.ptx" />
 
     <xi:include href="09-PS/main.ptx" />
-
+  -->
     <xi:include href="meta/backmatter.ptx" />
   </book>
 </pretext>


### PR DESCRIPTION
Changed the \frac to \dfrac in most instances in chapter DF. \frac not changed in exponents of functions, or in complex fractions (e.g. Activity 2.2.10)