### PR TITLE
Want to move content on orthogonal sets/bases to the beginning of the Gram-Schmidt section.

### DIFF
--- a/linear-algebra/source/future-ON/02.ptx
+++ b/linear-algebra/source/future-ON/02.ptx
@@ -9,33 +9,7 @@
         </ul>
     </objectives>
 
-<definition>
-    <statement>
-        <p>
-    A set <m>S</m> of vectors is called an <term>orthogonal set</term> provided <m>\vec u \cdot \vec v = 0</m> for any pair of vectors <m>\vec u</m>, <m>\vec v \in S</m> with <m>\vec u \ne \vec v</m>.
-        </p>
-    </statement>
-</definition>
 
-<activity estimated-time='5'>
-    <introduction>
-        <p>
-            If we rotate the standard basis of <m>\IR^2</m> by <m>45^{\circ}</m>, we produce the set <m>B=\left\{\vec b_1, \vec b_2\right\}=\left\{ \left[\begin{array}{c} \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} \end{array}\right], \left[\begin{array}{c} -\frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} \end{array}\right]\right\}</m>
-        </p>
-    </introduction>
-    <task><p>Determine the length of <m>\vec b_1</m> and <m>\vec b_2</m>.</p></task>
-    <task><p>Determine the dot product <m>\vec b_1 \cdot \vec b_2</m>.</p></task>
-    <task><p>Is <m>B</m> is an orthogonal set? Explain why or why not.</p></task>
-    <task><p>Is <m>B</m> is a basis of <m>\IR^2</m>? Explain why or why not.</p></task>
-</activity>
-
-<definition>
-    <statement>
-        <p>
-            A basis <m>B</m> of a vector space is called an <term>orthogonal basis</term> provided every pair of vectors in <m>B</m> is orthogonal. If, in addition, each vector in <m>B</m> is a unit vector, then <m>B</m> is called an <term>orthonormal basis</term>.
-        </p>
-    </statement>
-</definition>
 
     <subsection>
         <title>Videos</title>

--- a/linear-algebra/source/future-ON/03.ptx
+++ b/linear-algebra/source/future-ON/03.ptx
@@ -8,6 +8,35 @@
             </li>
         </ul>
     </objectives>
+<definition>
+    <statement>
+        <p>
+        A set <m>S</m> of vectors is called an <term>orthogonal set</term> provided <m>\vec u \cdot \vec v = 0</m> for any pair of vectors <m>\vec u</m>, <m>\vec v \in S</m> with <m>\vec u \ne \vec v</m>.
+        </p>
+    </statement>
+</definition>
+    
+<activity estimated-time='5'>
+    <introduction>
+        <p>
+            If we rotate the standard basis of <m>\IR^2</m> by <m>45^{\circ}</m>, we produce the set <m>B=\left\{\vec b_1, \vec b_2\right\}=\left\{ \left[\begin{array}{c} \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} \end{array}\right], \left[\begin{array}{c} -\frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} \end{array}\right]\right\}</m>
+        </p>
+    </introduction>
+    <task><p>Determine the length of <m>\vec b_1</m> and <m>\vec b_2</m>.</p></task>
+    <task><p>Determine the dot product <m>\vec b_1 \cdot \vec b_2</m>.</p></task>
+    <task><p>Is <m>B</m> is an orthogonal set? Explain why or why not.</p></task>
+    <task><p>Is <m>B</m> is a basis of <m>\IR^2</m>? Explain why or why not.</p></task>
+</activity>
+    
+<definition>
+    <statement>
+        <p>
+            A basis <m>B</m> of a vector space is called an <term>orthogonal basis</term> provided every pair of vectors in <m>B</m> is orthogonal. If, in addition, each vector in <m>B</m> is a unit vector, then <m>B</m> is called an <term>orthonormal basis</term>.
+        </p>
+    </statement>
+</definition>
+
+
 <activity estimated-time='10'>
     <statement>
         <p>


### PR DESCRIPTION
Looking to redesign these 2 sections to focus 02 on projections and 03 on Gram-Schmidt. I think the intro of 03 works well by introducing orthogonal sets, etc.