### PR TITLE
Better error message in Checkit preview for an undefined outcome

### DIFF
--- a/scripts/preview_outcome.py
+++ b/scripts/preview_outcome.py
@@ -14,12 +14,11 @@ def main(book:str, outcome:str, amount:int = 20):
     sage_library_path = Path("source", book, "sage")
     bank_root = ET.parse(exercise_path/"bank.xml")
     search_string = f'.//*[name()="slug" and text()="{outcome}"]/./..'
-    element_list = bank_root.xpath(search_string)
-    if element_list == []:
+    try:
+        outcome_ele = bank_root.xpath(search_string)[0]
+    except IndexError:
         error_message = f"{outcome} is not an outcome defined in {exercise_path}/bank.xml"
         raise ValueError(error_message)
-    else:
-        outcome_ele = element_list[0]
 
     # get path to sandbox
     sandbox_path = Path("exercise-sandbox")

--- a/scripts/preview_outcome.py
+++ b/scripts/preview_outcome.py
@@ -14,7 +14,12 @@ def main(book:str, outcome:str, amount:int = 20):
     sage_library_path = Path("source", book, "sage")
     bank_root = ET.parse(exercise_path/"bank.xml")
     search_string = f'.//*[name()="slug" and text()="{outcome}"]/./..'
-    outcome_ele = bank_root.xpath(search_string)[0]
+    element_list = bank_root.xpath(search_string)
+    if element_list == []:
+        error_message = f"{outcome} is not an outcome defined in {exercise_path}/bank.xml"
+        raise ValueError(error_message)
+    else:
+        outcome_ele = element_list[0]
 
     # get path to sandbox
     sandbox_path = Path("exercise-sandbox")


### PR DESCRIPTION
Currently, if you try to run `preview_outcome.py` with an outcome that is not defined in the `bank.xml`, an `IndexError: list index out of range` is raised, which is not very helpful (or at least, confused me for a couple minutes).  This raises a more informative error, e.g. `ValueError: E1 is not an outcome defined in source/precalculus/exercises/bank.xml`