### PR TITLE
Precalc checkit EQ7 remove duplicate

### DIFF
--- a/source/precalculus/exercises/outcomes/EQ/EQ7/generator.sage
+++ b/source/precalculus/exercises/outcomes/EQ/EQ7/generator.sage
@@ -26,7 +26,8 @@ class Generator(BaseGenerator):
       d=a
       c=choice([-6..-1,1..6])
       e=choice([-6..-1,1..6])
-      f=choice([-6..-1,1..6])
+      #If f=c, then necessarily b=e and we end up with LHS=RHS.  So let's avoid that
+      f=choice([ i for i in [-6..-1,1..6] if i!=c])
       b=(f-1)*a*(f-c)+e*(c-f+1)
       partition_points = [1-f]
 

--- a/source/precalculus/exercises/outcomes/EQ/EQ7/template.xml
+++ b/source/precalculus/exercises/outcomes/EQ/EQ7/template.xml
@@ -10,7 +10,7 @@
     <knowl>
         <content>
             <p>
-                <m>{{quadratic_ineq}}</m> 
+                <me>{{quadratic_ineq}}</me> 
             </p>
         </content>
         <outtro>
@@ -28,7 +28,7 @@
     <knowl>
         <content>
             <p>
-                <m>{{rational_ineq}}</m> 
+                <me>{{rational_ineq}}</me> 
             </p>
         </content>
         <outtro>


### PR DESCRIPTION
Closes #288 

It turned out if two parameters were equal, then this cascaded into both sides of the inequality being the same, making the problem less interesting.  This would have happened ~ 1/24 of the time.