### PR TITLE
Speed improvement in EQ5 checkit

### DIFF
--- a/source/precalculus/exercises/outcomes/EQ/EQ5/generator.sage
+++ b/source/precalculus/exercises/outcomes/EQ/EQ5/generator.sage
@@ -40,7 +40,14 @@ class Generator(BaseGenerator):
                        "method":"the quadratic formula", "roots": f"{latex(r1)}\\text{{ and }}{latex(r2)}"})
     shuffle(equations)
 
+    #Imaginary roots task
+    r1=choice([-5..,-1,1..5])+choice([1..5])*I
+    r2=conjugate(r1)
+    imaginary_equation = expand((x-r1)*(x-r2)) == 0
+    imaginary_roots = f"{latex(r1)}\\text{{ and }}{latex(r2)}"
 
     return {
-      "equations": equations
+      "equations": equations,
+      "imaginary_equation": imaginary_equation,
+      "imaginary_roots": imaginary_roots
     } 

--- a/source/precalculus/exercises/outcomes/EQ/EQ5/generator.sage
+++ b/source/precalculus/exercises/outcomes/EQ/EQ5/generator.sage
@@ -1,6 +1,7 @@
 load("../sage/common.sage")
 
 class Generator(BaseGenerator):
+  irrational_dict = TBILPrecal.small_irrationals(rational_part=[-8..1,1..8],full_list=True)
   def data(self):
     
 
@@ -33,9 +34,9 @@ class Generator(BaseGenerator):
     equations.append( { "equation":  x^2+2*a*x== b , "method":"completing the square", "roots": f"{latex(r1)}\\text{{ and }}{latex(r2)} "})
 
     #Quadratic Equation
-    irrationals = list(TBILPrecal.small_irrationals(rational_part=[-8..1,1..8]).items())[0]
-    r1,r2=irrationals[0]
-    c=irrationals[1]
+    irrational = choice(list(self.irrational_dict.keys()))
+    r1,r2=irrational
+    c=self.irrational_dict[irrational]
     equations.append( { "equation": c^2*x^2-(r1+r2)*c^2*x == expand(-1*c^2*r1*r2), 
                        "method":"the quadratic formula", "roots": f"{latex(r1)}\\text{{ and }}{latex(r2)}"})
     shuffle(equations)

--- a/source/precalculus/exercises/outcomes/EQ/EQ5/template.xml
+++ b/source/precalculus/exercises/outcomes/EQ/EQ5/template.xml
@@ -39,5 +39,15 @@
             </list>
         </outtro> 
     </knowl>
+    <knowl>
+        <content>
+            <p>Find all solutions of the below equation, including any complex solutions.
+                <me>{{imaginary_equation}}</me>
+            </p>
+        </content>
+        <outtro>
+            <p><m>{{imaginary_roots}}</m></p>
+        </outtro>
+    </knowl>
     
 </knowl>

--- a/source/precalculus/sage/common.sage
+++ b/source/precalculus/sage/common.sage
@@ -155,11 +155,14 @@ class TBILPrecal:
                           irrational_part=[2,3,5,6,7,8],
                           denominators=[i for i in range(-5,6) if i != 0],
                           dictionary=True,
-                          length=1):
+                          length=1,
+                          full_list=False):
         '''Generates a list or dictionary of uniqe irrational numbers of the form (a+sqrt(b))/c. 
         For a dictionary, keys are tuples of rationals and their conjugate, and values are the denominators.'''
         fulldict = { ((a+sqrt(b))/c,(a-sqrt(b))/c):c for a in rational_part for b in irrational_part for c in denominators}
-        dict= { pair:fulldict[pair] for pair in sample(list(fulldict.keys()),length)}
+        if full_list:
+            length=len(fulldict)
+        dict= { pair:fulldict[pair] for pair in sample(list(fulldict.keys()),min(length,len(fulldict)))}
         if dictionary:
             return dict
         else:


### PR DESCRIPTION
I noticed the EQ5 checkit was a bit slow to build (~1 second per outcome, which adds up when building the full bank).  The library method `small_irrationals` generates a dictionary of small irrationals to choose from each time it is run, so every time an outcome was generated the same dictionary of things was being constructed.  I refactored this as a static class variable so it is run once, and then selected from repeatedly.

To facilitate this, I tweaked the library function `small_irrationals` to more easily return the full dictionary for cases like this.

I think it is likely some other outcomes could be improved in this way too, which will help speed up the overall build (depending on how slow they are now).  Speed improvement was approximately a factor of 5 here.