### PR TITLE
Rename non-preview edition of Precalculus

### DIFF
--- a/site/pages/library.md
+++ b/site/pages/library.md
@@ -24,9 +24,9 @@ We currently offer classroom-ready materials for **Calculus** and
 - [Slides](https://library.tbil.org/2024/linear-algebra/print/TBIL-Linear-Algebra-Slides.pdf)
 - [Exercises](https://library.tbil.org/2024/linear-algebra/exercises/)
 
-We have also just released a Preview edition of materials for pre-calculus classrooms. Note that these have not yet been used in classrooms; instructors are encouraged to join the conversation at <http://chat.tbil.org> to join others trialing these activities in their classrooms in Fall 2024.
+We have also just released a Trial edition of materials for pre-calculus classrooms. Note that these have not yet been used in classrooms; instructors are encouraged to join the conversation at <http://chat.tbil.org> to join others trialing these activities in their classrooms in Fall 2024.  You may wish to use this in conjunction with the Preview edition below, which is constantly changing as we make updates and fix things.  
 
-#### Precalculus 2024 Preview Edition
+#### Precalculus 2024 Trial Edition
 
 - [HTML](https://library.tbil.org/2024/precalculus/)
     - [Instructor Edition](https://library.tbil.org/2024/precalculus/instructor/)


### PR DESCRIPTION
Calling the 2024 edition the '2024 Preview edition' keeps causing confusion with the 'PREVIEW' edition.  