### PR TITLE
Imprecise prompts in EV1

### DIFF
--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -344,7 +344,7 @@ The following are all equivalent statements:
 
  <activity estimated-time="10">
     <introduction>
-      <p>Consider this claim about a vector equation:</p>
+      <p>Consider the following claim:</p>
           <p><m>\left[\begin{array}{c} -6 \\ 2 \\ -6 \end{array}\right]</m>is a linear combination of the vectors <m>\left[\begin{array}{c} 1 \\ 0 \\ 2 \end{array}\right] , \left[\begin{array}{c} 3 \\ 0 \\ 6 \end{array}\right] , \left[\begin{array}{c} 2 \\ 0 \\ 4 \end{array}\right] , \text{ and } \left[\begin{array}{c} -4 \\ 1 \\ -5 \end{array}\right]</m>.</p>
         </introduction>
           <task>
@@ -372,7 +372,7 @@ The following are all equivalent statements:
 
  <activity estimated-time="10">
     <introduction>
-      <p>Consider this claim about a vector equation:</p>
+      <p>Consider the following claim:</p>
           <p><m>\left[\begin{array}{c} -5 \\ -1 \\ -7 \end{array}\right]</m> belongs to
           <m>\vspan\left\{\left[\begin{array}{c} 1 \\ 0 \\ 2 \end{array}\right] , \left[\begin{array}{c} 3 \\ 0 \\ 6 \end{array}\right] , 
           \left[\begin{array}{c} 2 \\ 0 \\ 4 \end{array}\right] , \left[\begin{array}{c} -4 \\ 1 \\ -5 \end{array}\right]\right\}</m>.</p>


### PR DESCRIPTION
The claims that students consider in Activities 2.1.11,12 are not, in fact, about vector equations, so I am suggesting we modify the prompt to simply "consider the following claim:"