### PR TITLE
Adjust EV6 spanning set

### DIFF
--- a/source/linear-algebra/exercises/outcomes/EV/EV6/generator.sage
+++ b/source/linear-algebra/exercises/outcomes/EV/EV6/generator.sage
@@ -3,15 +3,15 @@ load("../sage/common.sage")
 class Generator(BaseGenerator):
     def data(self):
         #Pick some  vectors in R4
-        n=choice([3,4,5])
-        dim=choice(range(2,n))
+        n=choice([4,5])
+        dim=choice([2,3])
         A=CheckIt.simple_random_matrix_of_rank(dim,columns=n,rows=4)
         basis=[A.column(i) for i in A.pivots()]
 
         return {
-        "vlist": vectorSet(A.columns()),
-        "basis": vectorSet(basis),
-        "dimension": dim,
-        "matrix": A,
-        "rref": A.rref(),
+            "vlist": vectorSet(A.columns()),
+            "basis": vectorSet(basis),
+            "dimension": dim,
+            "matrix": A,
+            "rref": A.rref(),
         }


### PR DESCRIPTION
Grading some EV6, and I don't like the examples of three vectors spanning dimension two: I'd rather each problem have a bit more meat to it.

Likewise edited to ensure the vectors don't span all of R^4, though I've yet to have any student tell me that {e_1,e_2,e_3,e_4} is a basis in that case.