### PR TITLE
Fix to AD3 Shadow problem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "xml.fileAssociations": [
         {
             "pattern": "**/source/**.ptx",
-            "systemId": "/home/vscode/.ptx/2.6.2/core/schema/pretext.rng"
+            "systemId": "/home/vscode/.vscode-remote/extensions/oscarlevin.pretext-tools-0.21.0/assets/schema/pretext.rng"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "xml.fileAssociations": [
         {
             "pattern": "**/source/**.ptx",
-            "systemId": "/home/vscode/.vscode-remote/extensions/oscarlevin.pretext-tools-0.21.0/assets/schema/pretext.rng"
+            "systemId": "/home/vscode/.ptx/2.6.2/core/schema/pretext.rng"
         }
     ]
 }

--- a/source/calculus/exercises/outcomes/AD/AD3/template.xml
+++ b/source/calculus/exercises/outcomes/AD/AD3/template.xml
@@ -36,11 +36,6 @@
     <!-- {{#shadow}} -->
 
             <content>
-                <!--
-                <p>
-                    Suppose a person who was <m> {{heightperson}} </m> feet tall was standing between a light on the ground and a wall.  They are <m>{{disttolight}}</m> feet away from the light and <m>{{disttowall}}</m> feet away from the wall.  If they start walking towards the {{persondirection}} at a speed of <m>{{personspeed}}</m> feet/second, how fast would the height of the shadow they cast change and in what direction?
-                </p>
-                 -->
                 <p>
                     {{name}} is <m>{{heightperson}}</m> ft tall, and is walking in a straight line from a light on the ground toward the {{persondirection}} at a rate of <m>{{personspeed}}</m> ft/sec. At the moment {{pronoun1}} <m>{{disttolight}}</m> ft away from the light (and <m>{{disttowall}}</m> ft from the wall), how fast is the height of {{pronoun2}} shadow changing? In which direction is the shadow changing?
                 </p>

--- a/source/calculus/exercises/outcomes/AD/AD3/template.xml
+++ b/source/calculus/exercises/outcomes/AD/AD3/template.xml
@@ -42,7 +42,7 @@
                 </p>
                  -->
                 <p>
-                    {{name}} is <m>{{heightperson}}</m> ft tall, and is walking in a straight line from a light on the ground toward a wall at a rate of <m>{{personspeed}}</m> ft/sec. At the moment {{pronoun1}} <m>{{disttolight}}</m> ft away from the light (and <m>{{disttowall}}</m> ft from the wall), how fast is the height of {{pronoun2}} shadow on the wall changing? In which direction is the shadow changing?
+                    {{name}} is <m>{{heightperson}}</m> ft tall, and is walking in a straight line from a light on the ground toward the {{persondirection}} at a rate of <m>{{personspeed}}</m> ft/sec. At the moment {{pronoun1}} <m>{{disttolight}}</m> ft away from the light (and <m>{{disttowall}}</m> ft from the wall), how fast is the height of {{pronoun2}} shadow changing? In which direction is the shadow changing?
                 </p>
             </content>
             <outtro>


### PR DESCRIPTION
The {{persondirection}} variable from the original, correct prompt was left off of the new prompt; I added it back in and amended wording.