### PR TITLE
typo in AT6 3.6.6

### DIFF
--- a/source/linear-algebra/source/03-AT/06.ptx
+++ b/source/linear-algebra/source/03-AT/06.ptx
@@ -338,7 +338,7 @@ S=\setList{1,y,y^2,y^3,y^4}.
                     </li>
                     <li>
                         <p>
-                            Yes; every polynomial in <m>\P^4</m> is a linear combination of the matrices in <m>S</m>.
+                            Yes; every polynomial in <m>\P^4</m> is a linear combination of the polynomials in <m>S</m>.
                         </p>
                     </li>
                 </ol>


### PR DESCRIPTION
"matrices" instead of "polynomials"