### PR TITLE
typo in 4.4.2 (b)

### DIFF
--- a/source/linear-algebra/source/04-MX/04.ptx
+++ b/source/linear-algebra/source/04-MX/04.ptx
@@ -83,7 +83,7 @@ left-multiplying? (<m>2R_3\to R_3</m>)
 <task>
     <p>
 Which of these tweaks of the identity matrix
-yields a matrix that swaps the first and third rows of <m>A</m>
+yields a matrix that swaps the second and third rows of <m>A</m>
 when left-multiplying? (<m>R_1\leftrightarrow R_3</m>)
   <me>
    \left[\begin{array}{ccc} \unknown &amp; \unknown &amp; \unknown \\ \unknown &amp; \unknown &amp; \unknown \\ \unknown &amp; \unknown &amp; \unknown \end{array}\right]


### PR DESCRIPTION
(first and third row)->(second and third)