### PR TITLE
Typo in EL3

### DIFF
--- a/source/precalculus/source/05-EL/03.ptx
+++ b/source/precalculus/source/05-EL/03.ptx
@@ -623,7 +623,7 @@
   <task>
     <statement>
       <p>
-        Set up an inquality that you must solve to find the domain.
+        Set up an inequality that you must solve to find the domain.
       </p>
     </statement>
     <answer>


### PR DESCRIPTION
typo in [Activity 5.3.13(a)](https://library.tbil.org/2024/precalculus/EL3.html#act-log-domain-2) 

"inquality"
