### PR TITLE
Fixed grammar in Applications and AT

### DIFF
--- a/source/linear-algebra/source/03-AT/02.ptx
+++ b/source/linear-algebra/source/03-AT/02.ptx
@@ -568,7 +568,7 @@ Write the standard matrix <m>[T(\vec e_1) \,\cdots\, T(\vec e_n)]</m> for <m>T</
 </p>     
 <exploration>
      <statement>
-    For each of the following properties, determine if it is held by the dot product. Either provide a proof it the property holds, or provide a counter-example if it does not.
+    For each of the following properties, determine if it is held by the dot product. Either provide a proof that the property holds, or provide a counter-example if it does not.
 
 <ul>
 <li>Distributive over addition (e.g., (<m>\vec{u} + \vec{v})\cdot \vec{w} = \vec{u}\cdot\vec{w} + \vec{v}\cdot\vec{w})?</m></li>

--- a/source/linear-algebra/source/03-AT/03.ptx
+++ b/source/linear-algebra/source/03-AT/03.ptx
@@ -641,7 +641,7 @@ The dimension of the image is called the <term>rank</term> of <m>T</m> (or <m>A<
     <task>
       <statement>
         <p>
-          What picture, or other study strategy would be helpful to you in conceptualizing how these defintions fit together?
+          What picture, or other study strategy would be helpful to you in conceptualizing how these definitions fit together?
         </p>
       </statement>
     </task>

--- a/source/linear-algebra/source/03-AT/04.ptx
+++ b/source/linear-algebra/source/03-AT/04.ptx
@@ -1038,9 +1038,9 @@ Which of the following must be true?
                 <statement>
                     Suppose that <m>f:V \rightarrow W</m> is a linear transformation between two vector spaces <m>V</m> and <m>W</m>. State carefully what conditions <m>f</m> must satisfy. Let <m>\vec{0_V}</m> and <m>\vec{0_W}</m> be the zero vectors in <m>V</m> and <m>W</m> respectively.
                     <ul>
-                    <li>Prove that <m>f</m> is one-to-one if and only if <m>f(\vec{0_V}) = \vec{0_W}</m>, and that <m>\vec{0_V}</m> is the unique element of <m>V</m> which is mapped to <m>\vec{0_W}</m>. Remember that this needs to be done in both directions. First prove the if and only if statement, and then show the uniqueness.</li>
+                    <li>Prove that <m>f</m> is one-to-one if and only if <m>f(\vec{0_V}) = \vec{0_W}</m>, and that <m>\vec{0_V}</m> is the unique element of <m>V</m> which is mapped to <m>\vec{0_W}</m>. Remember that this needs to be done in both directions. First, prove the if and only if statement, then show the uniqueness.</li>
 
-<li>Do not use subtraction in your proof. The only vector space operation we have is addition, and a structure preserving function only preserves addition. If you are writing <m>\vec{v} - \vec{v} = \vec{0}_V</m>, what you really mean is that <m>\vec{v} \oplus \vec{v}^{-1} = \vec{0}_V</m>, where <m>\vec{v}^{-1}</m> is the additive inverse of <m>\vec{v}</m>. </li>   </ul>
+<li>Do not use subtraction in your proof. The only vector space operation we have is addition, and a structure-preserving function only preserves addition. If you are writing <m>\vec{v} - \vec{v} = \vec{0}_V</m>, what you really mean is that <m>\vec{v} \oplus \vec{v}^{-1} = \vec{0}_V</m>, where <m>\vec{v}^{-1}</m> is the additive inverse of <m>\vec{v}</m>. </li>   </ul>
                 </statement>
     </exploration>
  <exploration><statement>

--- a/source/linear-algebra/source/03-AT/05.ptx
+++ b/source/linear-algebra/source/03-AT/05.ptx
@@ -70,7 +70,7 @@ Consider the following applications of properties of the real numbers
 <activity estimated-time='5'>
   <statement>
   <p>
-Which of the following properites of <m>\IR^2</m> Euclidean vectors is NOT true?
+Which of the following properties of <m>\IR^2</m> Euclidean vectors is NOT true?
   </p>
 <ol marker="A.">
 <li><p> <m>\left[\begin{array}{c} x_1\\x_2\end{array}\right]
@@ -123,7 +123,7 @@ Which of the following properites of <m>\IR^2</m> Euclidean vectors is NOT true?
 </activity>
 <observation>
     <p>
-      Consider the following applications of properites of the real numbers 
+      Consider the following applications of properties of the real numbers 
       <m>\mathbb R</m>:
     </p>
     <ol>
@@ -159,7 +159,7 @@ Which of the following properites of <m>\IR^2</m> Euclidean vectors is NOT true?
 <activity estimated-time='5'>
     <statement>
     <p>
-Which of the following properites of <m>\IR^2</m> Euclidean vectors is NOT true?
+Which of the following properties of <m>\IR^2</m> Euclidean vectors is NOT true?
     </p>
 <ol marker="A.">
 <li>
@@ -337,7 +337,7 @@ The space of <m>m \times n</m> <term>matrices</term>
 <remark>
     <p>
   Consider the
-  set <m>\IC</m> of complex numbers with the usual defintion for addition:
+  set <m>\IC</m> of complex numbers with the usual definition for addition:
   <m>(a+b\mathbf i)\oplus(c+d\mathbf i)=(a+c)+(b+d)\mathbf i</m>.
     </p>
     <p>Let 
@@ -687,14 +687,14 @@ for <em>all</em> <m>c\in \IR,\, (x_1,y_1),(x_2,y_2) \in V</m>.
         <statement>
           <p>
             What are some objects that are important to you personally, academically, or otherwise that appear vector-like to you? 
-            What makes them feel vector-like? Which axiom for vector spaces does not hold for these objects, if any. 
+            What makes them feel vector-like? Which axiom for vector spaces does not hold for these objects, if any? 
           </p>
         </statement>
        </task>
        <task>
         <statement>
           <p>
-            Our vector space axioms have eight properties. While these eight properties are enough to capture vectors, the objects that we study in the real-world often have additional structures not captured by these axioms. 
+            Our vector space axioms have eight properties. While these eight properties are enough to capture vectors, the objects that we study in the real world often have additional structures not captured by these axioms. 
             What are some structures that you have encountered in other classes, or in previous experiences, that are not captured by these eight axioms?
           </p>
         </statement>

--- a/source/linear-algebra/source/03-AT/06.ptx
+++ b/source/linear-algebra/source/03-AT/06.ptx
@@ -448,12 +448,12 @@ as a linear combination of polynomials from the set
     </introduction>
       <task>
         <statement>
-          <p> Describe the vector space involved in this problem, and an isomorphic Euclidean space and relevant Eucldean vectors that can be used to solve this problem. </p>
+          <p> Describe the vector space involved in this problem, and an isomorphic Euclidean space, and relevant Euclidean vectors that can be used to solve this problem. </p>
         </statement>
       </task>
       <task>
         <statement>
-          <p> Show how to construct an appropriate Euclidean vector from an approriate set of Euclidean vectors. </p>
+          <p> Show how to construct an appropriate Euclidean vector from an appropriate set of Euclidean vectors. </p>
         </statement>
       </task>
       <task>

--- a/source/linear-algebra/source/applications/pagerank.ptx
+++ b/source/linear-algebra/source/applications/pagerank.ptx
@@ -6,7 +6,7 @@
 
     <activity estimated-time="10">
         <title>
-The $978,000,000,000 Problem
+The $2,110,000,000,000 Problem
         </title>
         <statement>
             <p>
@@ -58,7 +58,7 @@ most important to least important.
 
     <observation>
         <title>
-The $978,000,000,000 Idea
+The $2,110,000,000,000 Idea
         </title>
         <statement>
         <p>
@@ -187,7 +187,7 @@ the matrix equation <m>A\vec{x}=1\vec{x}</m>.
     <activity estimated-time="5">
         <statement>
         <p>
-Thus, our $978,000,000,000 problem is what kind of problem?
+Thus, our $2,110,000,000,000 problem is what kind of problem?
             <me>
     \left[\begin{array}{ccc}0&amp;1&amp;0\\\frac{1}{2}&amp;0&amp;\frac{1}{2}\\\frac{1}{2}&amp;0&amp;0\end{array}\right]
     \left[\begin{array}{c}x_1\\x_2\\x_3\end{array}\right]
@@ -395,7 +395,7 @@ it's reasonable to consider page <m>2</m> as the most important page.
             </me>
             </p>
             <p>
-Based upon this page rank vector,
+Based on this page rank vector,
 here is a complete ranking of all seven pages from most important to least important:
             <me>
   2, 4, 1, 3, 7, 5, 6

--- a/source/linear-algebra/source/applications/truss.ptx
+++ b/source/linear-algebra/source/applications/truss.ptx
@@ -82,7 +82,7 @@ determine many of the forces at play.
     <remark>
         <statement>
             <p>
-For example, at the bottom left node there are 3 forces acting.
+For example, at the bottom left node, 3 forces are acting.
             </p>
         <figure>
             <image width="75%" xml:id="truss-image-simple-forces">
@@ -287,7 +287,7 @@ one variable may be used to represent each.
     <observation>
         <statement>
             <p>
-Since the angle of the normal forces for each anchor point are unknown,
+Since the angle of the normal forces for each anchor point is unknown,
 two variables may be used to represent each.
             </p>
         <figure>
@@ -388,7 +388,7 @@ x_7\begin{bmatrix}\unknown\\\unknown\end{bmatrix}=
         <statement>
             <p>
 The full augmented matrix given by the ten equations in this linear system
-is given below, where the eleven columns correspond to <m>x_1,\dots,x_7,y_1,y_2,z_1,z_2</m>,
+is shown below, where the eleven columns correspond to <m>x_1,\dots,x_7,y_1,y_2,z_1,z_2</m>,
 and the ten rows correspond to the horizontal and vertical components of the
 forces acting at <m>A,\dots,E</m>.
             </p>
@@ -455,7 +455,7 @@ y_2=z_2&amp;=5000
             </md>
             <p>
 In particular, the negative <m>x_1,x_2,x_5</m> represent tension (forces pointing into the nodes),
-and the postive <m>x_3,x_4</m> represent compression (forces pointing out of the nodes).
+and the positive <m>x_3,x_4</m> represent compression (forces pointing out of the nodes).
 The vertical normal forces <m>y_2+z_2</m> counteract the <m>10000</m> load.
             </p>
         <figure>


### PR DESCRIPTION
Fixed minor grammar and spelling issues in the Applications and Algebraic Properties of Linear Maps (AT) sections, with the help of the Grammarly writing tool.