### PR TITLE
Add <p> tags to answers on 2.1.16

### DIFF
--- a/source/precalculus/source/02-FN/01.ptx
+++ b/source/precalculus/source/02-FN/01.ptx
@@ -504,7 +504,9 @@
     </p>
   </statement>
     <answer>
+      <p>
      If <m>x=4</m>, <m>y</m> could be <m>-2</m> or <m>2</m>. Given that there are two outputs for a given <m>x</m>, then <m>x=y^2</m> is not a function.
+     </p>
     </answer>
   </task>
   
@@ -525,7 +527,9 @@
   </p>
   </statement>
   <answer>
+    <p>
     If <m>x=4</m>, <m>y=50</m>. For every input (<m>x</m>-value), there is exactly one output (<m>y</m>-value) so <m>y=3x^2+2</m> is a function.
+    </p>
   </answer>
 </task>
 
@@ -546,7 +550,9 @@
   </p>
 </statement>
   <answer>
+    <p>
     If <m>x=4</m>, <m>y</m> could be <m>-3</m> or <m>3</m>. Given that there are two outputs for a given <m>x</m>, then <m>x^2+y^2=25</m> is not a function.
+    </p>
   </answer>
 </task>
 
@@ -567,7 +573,9 @@
   </p>
 </statement>
   <answer>
+    <p>
     If <m>x=4</m>, <m>y=-19</m>. For every input (<m>x</m>-value), there is exactly one output (<m>y</m>-value) so <m>y=-4x-3</m> is a function.
+    </p>
   </answer>
 </task>
 <task>
@@ -577,7 +585,9 @@
     </p>
   </statement>
     <answer>
+      <p>
       Students may have different answers. Ideally, you want students to see that they can check whether a given relation is a function in more than one way. They can test values (as this activity did by leading them to plug in values) or by using the vertical line test on a graph.
+      </p>
     </answer>
 </task>
 </activity>


### PR DESCRIPTION
All of the `<answer>`s on 2.1.16 were missing `<p>` tags, causing only the math to be displayed and not the text that was in the source.  Closes #540 