### PR TITLE
Add missing p to intro of 2.1.12

### DIFF
--- a/source/precalculus/source/02-FN/01.ptx
+++ b/source/precalculus/source/02-FN/01.ptx
@@ -331,7 +331,9 @@
 
     <activity xml:id="FN1-determine-function-from-graph">
     <introduction>
+      <p>
       Determine whether each of the following relations is a function.
+      </p>
     </introduction>
 <task>
   <statement>


### PR DESCRIPTION
The `<introduction>` to 2.1.12 was missing  `<p>` tags and thus not displaying.

Closes #539 