### PR TITLE
fn3 updates

### DIFF
--- a/source/precalculus/source/02-FN/03.ptx
+++ b/source/precalculus/source/02-FN/03.ptx
@@ -576,7 +576,7 @@
           <p>
             At approximately what value of <m>x</m> is there a global minimum?
             <ol marker= "A." cols="4">
-              <li> <m>x=\approx -4</m> </li>
+              <li> <m>x\approx -4</m> </li>
               <li> <m>x\approx -2</m> </li>
               <li> <m>x\approx 2</m> </li>
               <li> <m>x\approx 5</m> </li></ol></p>

--- a/source/precalculus/source/02-FN/03.ptx
+++ b/source/precalculus/source/02-FN/03.ptx
@@ -54,7 +54,7 @@
       <task>
         <statement>
         <p> What are the <m>x</m>-intercept(s) of <m>f(x)</m>? 
-          <ol marker= "A." cols="2">
+          <ol marker= "A." cols="4">
             <li> <m>(0, -4)</m> </li>
             <li> <m>(-2, 0)</m> </li>
             <li> <m>(-4, 0)</m> </li>
@@ -69,7 +69,7 @@
         <task>
           <statement>
           <p> What are the <m>x</m>-intercept(s) of <m>g(x)</m>? 
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(0, -3)</m> </li>
               <li> <m>(-1, 0)</m> </li>
               <li> <m>(3, 0)</m> </li>
@@ -84,7 +84,7 @@
           <task>
             <statement>
             <p> What are the <m>y</m>-intercept(s) of <m>f(x)</m>? 
-              <ol marker= "A." cols="2">
+              <ol marker= "A." cols="4">
                 <li> <m>(0, -4)</m> </li>
                 <li> <m>(-2, 0)</m> </li>
                 <li> <m>(-4, 0)</m> </li>
@@ -99,7 +99,7 @@
             <task>
               <statement>
               <p> What are the <m>y</m>-intercept(s) of <m>g(x)</m>? 
-                <ol marker= "A." cols="2">
+                <ol marker= "A." cols="4">
                   <li> <m>(0, -3)</m> </li>
               <li> <m>(-1, 0)</m> </li>
               <li> <m>(3, 0)</m> </li>
@@ -204,7 +204,7 @@
         <statement>
           <p>
             What interval represents the domain you drew in part (a)?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>[4, -4]</m> </li>
               <li> <m>[-4, 4]</m> </li>
               <li> <m>(-4, 4)</m> </li>
@@ -232,7 +232,7 @@
         <statement>
           <p>
             What interval represents the range you drew in part (c)?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-5, 4)</m> </li>
               <li> <m>[-4, 4]</m> </li>
               <li> <m>[-5, 4]</m> </li>
@@ -265,7 +265,7 @@
         <statement>
           <p>
             What is the domain of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>[4, \infty)</m> </li>
               <li> <m>(-\infty, 0]</m> </li>
               <li> <m>(-\infty, 4]</m> </li>
@@ -281,7 +281,7 @@
         <statement>
           <p>
             What is the range of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>[4, \infty)</m> </li>
               <li> <m>(-\infty, 0]</m> </li>
               <li> <m>(-\infty, 4]</m> </li>
@@ -323,7 +323,7 @@
         <statement>
           <p>
             What is the domain of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-\infty, 3)</m> </li>
               <li> <m>(\infty, -4]</m> </li>
               <li> <m>(-4, \infty)</m> </li>
@@ -339,7 +339,7 @@
         <statement>
           <p>
             What is the range of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-\infty, 3)</m> </li>
               <li> <m>(\infty, -4]</m> </li>
               <li> <m>(-4, \infty)</m> </li>
@@ -377,7 +377,7 @@
         <statement>
           <p>
             What is the domain of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-3, 5)</m> </li>
               <li> <m>(-5, 7)</m> </li>
               <li> <m>[-5, 7]</m> </li>
@@ -393,7 +393,7 @@
         <statement>
           <p>
             What is the range of this graph?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-3, 5)</m> </li>
               <li> <m>(-5, 6)</m> </li>
               <li> <m>[-5, 6]</m> </li>
@@ -441,7 +441,7 @@
         <statement>
           <p>
             Which interval best represents where the function is increasing?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-\infty, -1]</m> </li>
               <li> <m>(-\infty, -1)</m> </li>
               <li> <m>(-1,\infty)</m> </li>
@@ -469,7 +469,7 @@
         <statement>
           <p>
             Which interval best represents where the function is decreasing?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>(-\infty, -1]</m> </li>
               <li> <m>(-\infty, -1)</m> </li>
               <li> <m>(-1,\infty)</m> </li>
@@ -543,7 +543,7 @@
         <statement>
           <p>
             At what value of <m>x</m> is there a global maximum?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>x=-4</m> </li>
               <li> <m>x=-2</m> </li>
               <li> <m>x=2</m> </li>
@@ -559,7 +559,7 @@
         <statement>
           <p>
             What is the global maximum value?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>10</m> </li>
               <li> <m>7</m> </li>
               <li> <m>4</m> </li>
@@ -574,12 +574,12 @@
       <task>
         <statement>
           <p>
-            At what value of <m>x</m> is there a global minimum?
-            <ol marker= "A." cols="2">
-              <li> <m>x=-4</m> </li>
-              <li> <m>x=-2</m> </li>
-              <li> <m>x=2</m> </li>
-              <li> <m>x=5</m> </li></ol></p>
+            At approximately what value of <m>x</m> is there a global minimum?
+            <ol marker= "A." cols="4">
+              <li> <m>x=\approx -4</m> </li>
+              <li> <m>x\approx -2</m> </li>
+              <li> <m>x\approx 2</m> </li>
+              <li> <m>x\approx 5</m> </li></ol></p>
         </statement>
         <answer>
           <p>
@@ -591,7 +591,7 @@
         <statement>
           <p>
             What is the global minimum value?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>10</m> </li>
               <li> <m>7</m> </li>
               <li> <m>4</m> </li>
@@ -607,7 +607,7 @@
         <statement>
           <p>
             At approximately what value of <m>x</m> is there a local maximum?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>x \approx -4</m> </li>
               <li> <m>x \approx -2</m> </li>
               <li> <m>x \approx 2</m> </li>
@@ -623,7 +623,7 @@
         <statement>
           <p>
             What is the local maximum value?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>10</m> </li>
               <li> <m>7</m> </li>
               <li> <m>4</m> </li>
@@ -639,7 +639,7 @@
         <statement>
           <p>
             At approximately what value of <m>x</m> is there a local minimum?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>x \approx -4</m> </li>
               <li> <m>x \approx -2</m> </li>
               <li> <m>x \approx 2</m> </li>
@@ -655,7 +655,7 @@
         <statement>
           <p>
             What is the local minimum value?
-            <ol marker= "A." cols="2">
+            <ol marker= "A." cols="4">
               <li> <m>10</m> </li>
               <li> <m>7</m> </li>
               <li> <m>4</m> </li>
@@ -696,10 +696,10 @@
   <statement>
     <p>
       What is the value of <m>f(0)</m>?
-      <ol marker= "A." cols="1">
+      <ol marker= "A." cols="3">
         <li> <m>1</m> </li>
         <li> <m>0</m> </li>
-        <li> There is no local minimum </li></ol></p>
+        <li> <m>f(0)</m> does not exist </li></ol></p>
   </statement>
   <answer>
     <p>
@@ -711,8 +711,8 @@
 <task>
   <statement>
     <p>
-      What is the local minimum of <m>f(x)</m>?
-      <ol marker= "A." cols="1">
+      What is the local minimum value of <m>f(x)</m>?
+      <ol marker= "A." cols="3">
         <li> <m>1</m> </li>
         <li> <m>0</m> </li>
         <li> There is no local minimum </li></ol></p>
@@ -726,8 +726,8 @@
 <task>
   <statement> 
     <p>
-      What is the global minimum of <m>f(x)</m>?
-      <ol marker= "A." cols="1">
+      What is the global minimum value of <m>f(x)</m>?
+      <ol marker= "A." cols="3">
         <li> <m>1</m> </li>
         <li> <m>0</m> </li>
         <li> There is no global minimum </li></ol></p>


### PR DESCRIPTION
A few things in here:

1 - Made a lot of the answer choices 4 columns instead of two to save some space and to go with our general use of 4 columns when answers are short. This was helpful because there are large graphs and a lot of scrolling between the graphs and the questions.

2 - In 2.3.20 -- Changed some of the = to approximately. In particular, the global min looks like it occurs at a little less than x=2, not at 2.