### PR TITLE
Fix test sageplots with included library

### DIFF
--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -48,6 +48,8 @@ class TBIL:
             if i % label_skip == 0:
                 P += line([(i,-0.2),(i,0.2)],color="black")
                 P += text(f"${i}$", (i,-0.6),color="black")
+        
+        P.axes(False)
         return P
     
     @staticmethod
@@ -81,6 +83,7 @@ class TBIL:
                 P += text(")", (end,0), color="#0088ff", fontsize=18)
             else:
                 P += text("]", (end,0), color="#0088ff", fontsize=18)
+        P.axes(False)
         return P
 
     @staticmethod

--- a/source/precalculus/source/01-EQ/07.ptx
+++ b/source/precalculus/source/01-EQ/07.ptx
@@ -141,12 +141,13 @@
       <p>Draw a number line representing your solution.</p>
       </statement>
     <answer>
-      <image>
+    <image>
         <sageplot>
-          <xi:include parse="text" href="../../../common/sagemath/library.sage"/>
-          p = TBIL.numberline_plot()
-          p += TBIL.inequality_plot(start=-2,end=7,label_endpoints=False)
-          p
+<xi:include parse="text" href="../../../common/sagemath/library.sage"/>
+p = TBIL.numberline_plot()
+p += TBIL.inequality_plot(start=-2,end=7,label_endpoints=False)
+p.axes(False)
+p
         </sageplot>
       </image>
     </answer>
@@ -176,10 +177,11 @@
   <answer>
     <image>
       <sageplot>
-        <xi:include parse="text" href="../../../common/sagemath/library.sage"/>
-        p = TBIL.numberline_plot()
-        p += TBIL.inequality_plot(start=-5, end=-3,strict_start=False,strict_end=False,label_endpoints=False)
-        p
+<xi:include parse="text" href="../../../common/sagemath/library.sage"/>
+p = TBIL.numberline_plot()
+p += TBIL.inequality_plot(start=-5, end=-3,strict_start=False,strict_end=False,label_endpoints=False)
+p.axes(False)
+p
       </sageplot>
     </image>
   </answer>
@@ -336,11 +338,12 @@
     <answer>
       <image>
         <sageplot>
-          <xi:include parse="text" href="../../../common/sagemath/library.sage"/>
-          p = TBIL.numberline_plot()
-          p += TBIL.inequality_plot(end=-12,strict_end=False,label_endpoints=False)
-          p += TBIL.inequality_plot(start=-5,end=2,label_endpoints=False)
-          p
+<xi:include parse="text" href="../../../common/sagemath/library.sage"/>
+p = TBIL.numberline_plot(radius=15)
+p += TBIL.inequality_plot(end=-12,strict_end=False,label_endpoints=False,scale=15)
+p += TBIL.inequality_plot(start=-5,end=2,label_endpoints=False,scale=15)
+p.axes(False)
+p
         </sageplot>
       </image>
     </answer>


### PR DESCRIPTION
When using an `<xi:include>` in sage code, it seems that everything needs to be flush left or Python gets angry.  This fixes a few test images inserted in #629 that were breaking the build.