### PR TITLE
Move answer out of statement

### DIFF
--- a/source/precalculus/source/01-EQ/07.ptx
+++ b/source/precalculus/source/01-EQ/07.ptx
@@ -321,12 +321,12 @@ where <m>a</m>, <m>b</m>, and <m>c</m> are real numbers and <m>a \neq 0</m>.
       <p> 
         These solutions (that you got in part (b)) correspond to all of the <m>x</m>-intercepts of the graph, and are the only spots where the <m>y</m>-values on either side might change from positive to negative or negative to positive. So, with our two <m>x</m>-intercepts, we have divided our graph into three intervals. What are these three intervals? 
       </p>
+      </statement>
       <answer>
         <p>
           <m>(-\infty, -4)</m>, <m>(-4,8)</m>, and <m>(8, \infty)</m>
         </p>
       </answer>
-      </statement>
       </task>
         
       <task>


### PR DESCRIPTION
Closes #640 (I hope)

Found a rogue `<answer>` that had snuck inside a `<statement>`.  I feel like that should have broke the build in the codespace, but apparently not.  Hoping this fixes the build...