### PR TITLE
Fix index error in sage helper function

### DIFF
--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -120,7 +120,7 @@ class TBIL:
                         intervals.append(f"({partition_points[-1]}, \\infty)")
                 else:
                     s=""
-                    if partition_points[i] not in undefined_points and inequality.subs({x:partition_points[i]}):
+                    if partition_points[i-1] not in undefined_points and inequality.subs({x:partition_points[i-1]}):
                         s+="["
                     else:
                         s+="("


### PR DESCRIPTION
Closes #644.  There was an index error, look at line 127 and its clear that I was checking the right end point to typeset the [ or ( on the left side of the interval.  This can be tested with Task 2 of the present EQ7, or once #643 is merged, the new PR9.