### PR TITLE
Add features to TBIL.plot_angle()

### DIFF
--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -9,7 +9,10 @@ class TBIL:
         show_axes=True,
         show_unit_circle=False,
         show_unit_point=False,
-        show_angle_value=False
+        label_unit_point=False,
+        show_angle_value=False,
+        show_triangle=False,
+        triangle_labels=False,
     ):
         reference_coordinate = (cos(reference_angle),sin(reference_angle))
         end_angle = reference_angle+angle
@@ -24,9 +27,26 @@ class TBIL:
             p+=text(f"${latex(angle)}$",(0.2*c for c in mid_coordinate), fontsize="24")
         if show_unit_point:
             p+=point(end_coordinate,size="50",color="red")
-            p+=text(f"$\\left({latex(cos(end_angle))},{latex(sin(end_angle))}\\right)$", (1.4*c for c in end_coordinate),color="black",fontsize="18")
+        if label_unit_point:
+            if type(label_unit_point) is tuple and len(label_unit_point)==2:
+                label=f"$\\left({label_unit_point[0]},{label_unit_point[1]}\\right)$"
+            else:
+                label=f"$\\left({latex(cos(end_angle))},{latex(sin(end_angle))}\\right)$"
+            p+=text(label, (1.4*c for c in end_coordinate),color="black",fontsize="18")
         if show_unit_circle:
             p+=circle((0,0),1,color="#ddd")
+        if show_triangle:
+            p+=line([(0,0),(end_coordinate[0],0),end_coordinate],color="green",thickness=2)
+        if triangle_labels:
+            if type(triangle_labels) is tuple and len(triangle_labels)==2:
+                xlabel=triangle_labels[0]
+                ylabel=triangle_labels[1]
+            else:
+                xlabel=f"${latex(cos(end_angle))}$"
+                ylabel=f"${latex(sin(end_angle))}$"
+            p+=text(xlabel, (0.5*end_coordinate[0],0.2),color="green",fontsize="14")
+            p+=text(ylabel, (end_coordinate[0]+0.2, 0.5*end_coordinate[1]),color="green",fontsize="14")
+            
         if not show_axes:
             p.axes(False)
         p.xmin(-1)

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -11,10 +11,13 @@ class TBIL:
         show_unit_point=False,
         label_unit_point=False,
         show_angle_value=False,
+        show_reference_angle_value=False,
         show_triangle=False,
         triangle_labels=False,
     ):
         reference_coordinate = (cos(reference_angle),sin(reference_angle))
+        mid_reference_angle=reference_angle/2
+        mid_reference_coordinate = (cos(mid_reference_angle),sin(mid_reference_angle))
         end_angle = reference_angle+angle
         end_coordinate = (cos(end_angle),sin(end_angle))
         mid_angle = reference_angle+angle/2
@@ -24,7 +27,10 @@ class TBIL:
         p+=arrow((0,0),end_coordinate) #TODO hide arrowheads when show_unit_circle
         p+=arc((0,0),0.1,sector=(reference_angle, end_angle),color="black") #TODO add arrowhead
         if show_angle_value:
-            p+=text(f"${latex(angle)}$",(0.2*c for c in mid_coordinate), fontsize="24")
+            p+=text(f"${latex(angle)}$",(0.2*c for c in mid_coordinate), fontsize="16")
+        if show_reference_angle_value:
+            p+=arc((0,0),0.1,sector=(0, reference_angle),color="black") 
+            p+=text(f"${latex(reference_angle)}$",(0.2*c for c in mid_reference_coordinate), fontsize="16")
         if show_unit_point:
             p+=point(end_coordinate,size="50",color="red")
         if label_unit_point:
@@ -36,7 +42,13 @@ class TBIL:
         if show_unit_circle:
             p+=circle((0,0),1,color="#ddd")
         if show_triangle:
-            p+=line([(0,0),(end_coordinate[0],0),end_coordinate],color="green",thickness=2)
+            if cos(angle)*sin(angle)!=0:
+                p+=line([(0,0),(end_coordinate[0],0),end_coordinate],color="green",thickness=2)
+                #Little square in corner
+                delta=0.08
+                xdelta = -1*delta*cos(angle)/abs(cos(angle))
+                ydelta = delta*sin(angle)/abs(sin(angle))
+                p+=line([(end_coordinate[0],ydelta),(end_coordinate[0]+xdelta,ydelta),(end_coordinate[0]+xdelta,0)],color="green")
         if triangle_labels:
             if type(triangle_labels) is tuple and len(triangle_labels)==2:
                 xlabel=triangle_labels[0]

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -14,7 +14,15 @@ class TBIL:
         show_reference_angle_value=False,
         show_triangle=False,
         triangle_labels=False,
+        degree_labels=False,
     ):
+        if degree_labels:
+            angle_label = f"${latex(angle*180/pi)}^\\circ$"
+            reference_angle_label = f"${latex(reference_angle*180/pi)}^\\circ$"
+        else:
+            angle_label = f"${latex(angle)}$"
+            reference_angle_label = f"${latex(reference_angle)}$"
+
         reference_coordinate = (cos(reference_angle),sin(reference_angle))
         mid_reference_angle=reference_angle/2
         mid_reference_coordinate = (cos(mid_reference_angle),sin(mid_reference_angle))
@@ -27,10 +35,10 @@ class TBIL:
         p+=arrow((0,0),end_coordinate) #TODO hide arrowheads when show_unit_circle
         p+=arc((0,0),0.1,sector=(reference_angle, end_angle),color="black") #TODO add arrowhead
         if show_angle_value:
-            p+=text(f"${latex(angle)}$",(0.2*c for c in mid_coordinate), fontsize="16")
+            p+=text(angle_label,(0.2*c for c in mid_coordinate), fontsize="16")
         if show_reference_angle_value:
             p+=arc((0,0),0.1,sector=(0, reference_angle),color="black") 
-            p+=text(f"${latex(reference_angle)}$",(0.2*c for c in mid_reference_coordinate), fontsize="16")
+            p+=text(reference_angle_label,(0.2*c for c in mid_reference_coordinate), fontsize="16")
         if show_unit_point:
             p+=point(end_coordinate,size="50",color="red")
         if label_unit_point:


### PR DESCRIPTION
Based on what @AbbyANoble was trying to do today, I added a few (optional) features to `TBIL.plot_angle()`.  New features:

- A `label_unit_point` argument that controls the appearance of the label at the endpoint. If false, no labels appear.  If a tuple is passed, this will be the x and y components of the label.  Otherwise, the x and y value of the end point are used.
- A `show_triangle` argument that will draw the right triangle
- A `triangle_labels` argument that will label the legs of this triangle.  Passing a tuple allows the user to specify these labels, otherwise the lengths are used for any other true value.

@AbbyANoble were there any other features that might be helpful to add?

Once this is merged I'll update the wiki to document these features.