### PR TITLE
Add trig_plot function

### DIFF
--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -187,11 +187,10 @@ class TBIL:
         custom_ticks=[]
         custom_tick_labels=[]
         for x in [xmin+delta*i for i in [0.. int((xmax-xmin)/delta)]]:
+            custom_ticks.append(x)
             if denominator(x) != 1:
                 custom_tick_labels.append(f"$\\dfrac{{{latex(numerator(x))}}}{{{denominator(x)}}}$")
-                custom_ticks.append(x)
             else:
-                custom_ticks.append(x)
                 custom_tick_labels.append(f"${latex(x)}$")
                 
         #Default formatting

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -177,6 +177,37 @@ class TBIL:
         return P
 
     @staticmethod
+    def trig_plot(f, *args, **kwds):
+        xmin=-2*pi
+        xmax=4*pi
+        if 'ticks' not in kwds.keys() or type(kwds['ticks']) is not sage.symbolic.expression.Expression:
+            delta=pi/4
+        else:
+            delta=kwds['ticks']
+        custom_ticks=[]
+        custom_tick_labels=[]
+        for x in [xmin+delta*i for i in [0.. int((xmax-xmin)/delta)]]:
+            if denominator(x) != 1:
+                custom_tick_labels.append(f"$\\dfrac{{{latex(numerator(x))}}}{{{denominator(x)}}}$")
+                custom_ticks.append(x)
+            else:
+                custom_ticks.append(x)
+                custom_tick_labels.append(f"${latex(x)}$")
+                
+        #Default formatting
+        if 'color' not in kwds.keys():
+            kwds['color']='blue'
+        if 'thickness' not in kwds.keys():
+            kwds['thickness']=3
+            
+        kwds['ticks']=[custom_ticks,0.5]
+        kwds['tick_formatter']=[custom_tick_labels,"latex"]
+                
+        p=plot(f, *args, **kwds)
+        return p
+
+
+    @staticmethod
     def small_rationals(numerators=range(-8,9), 
                         denominators=None,
                         dictionary=True,

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -178,8 +178,17 @@ class TBIL:
 
     @staticmethod
     def trig_plot(f, *args, **kwds):
-        xmin=-2*pi
-        xmax=4*pi
+        if len(args)==0:
+            raise ValueError("Second positional argument should be a tuple of the form (var, min, max) or (xmin, xmax)")
+        if type(args[0]) is tuple and len(args[0])==2:
+            xmin=args[0][0]
+            xmax=args[0][1]
+        elif type(args[0]) is tuple and len(args[0])==3:
+            xmin=args[0][1]
+            xmax=args[0][2]
+        else:         
+            xmin=0
+            xmax=2*pi
         if 'ticks' not in kwds.keys() or type(kwds['ticks']) is not sage.symbolic.expression.Expression:
             delta=pi/4
         else:

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -177,6 +177,17 @@ class TBIL:
         return P
 
     @staticmethod
+    def typeset_angle(theta):
+        if type(theta) is not sage.symbolic.expression.Expression:
+            return latex(theta)
+        elif not theta.is_rational_expression(): 
+            return latex(theta)
+        elif denominator(theta)==1:
+            return latex(theta)
+        else:
+            return f"$\\dfrac{{{latex(numerator(theta))}}}{{{denominator(theta)}}}$"
+
+    @staticmethod
     def trig_plot(f, *args, **kwds):
         if len(args)==0:
             raise ValueError("Second positional argument should be a tuple of the form (var, min, max) or (xmin, xmax)")
@@ -198,7 +209,7 @@ class TBIL:
         for x in [xmin+delta*i for i in [0.. int((xmax-xmin)/delta)]]:
             custom_ticks.append(x)
             if denominator(x) != 1:
-                custom_tick_labels.append(f"$\\dfrac{{{latex(numerator(x))}}}{{{denominator(x)}}}$")
+                custom_tick_labels.append(TBIL.typeset_angle(x))
             else:
                 custom_tick_labels.append(f"${latex(x)}$")
                 

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -208,10 +208,7 @@ class TBIL:
         custom_tick_labels=[]
         for x in [xmin+delta*i for i in [0.. int((xmax-xmin)/delta)]]:
             custom_ticks.append(x)
-            if denominator(x) != 1:
-                custom_tick_labels.append(TBIL.typeset_angle(x))
-            else:
-                custom_tick_labels.append(f"${latex(x)}$")
+            custom_tick_labels.append(TBIL.typeset_angle(x))
                 
         #Default formatting
         if 'color' not in kwds.keys():

--- a/source/common/sagemath/library.sage
+++ b/source/common/sagemath/library.sage
@@ -179,11 +179,11 @@ class TBIL:
     @staticmethod
     def typeset_angle(theta):
         if type(theta) is not sage.symbolic.expression.Expression:
-            return latex(theta)
+            return f"${latex(theta)}$"
         elif not theta.is_rational_expression(): 
-            return latex(theta)
+            return f"${latex(theta)}$"
         elif denominator(theta)==1:
-            return latex(theta)
+            return f"${latex(theta)}$"
         else:
             return f"$\\dfrac{{{latex(numerator(theta))}}}{{{denominator(theta)}}}$"
 

--- a/source/precalculus/source/07-PF/01.ptx
+++ b/source/precalculus/source/07-PF/01.ptx
@@ -470,10 +470,8 @@ p
           <p>
             <image>
               <sageplot>
-f(x) = sin(x)
-p=Graphics()
-p+=plot(f, (x, -6.28, 12.56), color='blue', thickness=3, detect_poles=True,ticks=[pi/4,0.5], tick_formatter=pi)
-p
+<xi:include parse="text" href="../../../common/sagemath/library.sage"/>
+TBIL.trig_plot(sin(x),(x,-2*pi,4*pi),ticks=pi/2)
               </sageplot>
             </image> 
           </p>


### PR DESCRIPTION
See #533 , this library function allows users to easily set labels along the $x$-axis to integer multiples of a rational fraction of pi, as we commonly want to do with graphs of trig functions, but with labels typeset as e.g. $\frac{3\pi}{2}$ instead of $\frac{3}{2}\pi$.  All arguments other than `ticks` are passed along to the underlying plot function, allowing for further customization.

`TBIL.trig_plot(sin(x),(x,0,4*pi),ticks=pi/2,color='red')`
![image](https://github.com/user-attachments/assets/c81e92f9-fe73-441d-ad8b-2a4facec2f59)
