### PR TITLE
Missing p tags in PR3

### DIFF
--- a/source/precalculus/source/04-PR/03.ptx
+++ b/source/precalculus/source/04-PR/03.ptx
@@ -196,15 +196,14 @@ Use the graphs of the following polynomial functions to answer the questions bel
   </statement>
 </definition>
 
-<activity
-    xml:id="degree-and-leading-coefficient-of-polynomial-graphs">
-      <introduction>
+<activity xml:id="degree-and-leading-coefficient-of-polynomial-graphs">
+      <introduction> <p>
 Let's refer back to the graphs in <xref ref="act-end-behavior-of-polynomial-functions"/> and look at the equations of those polynomial functions. Let's apply <xref ref="def-degree-and-leading-coefficient"/> to see if we can determine how the degree and leading coefficients of those graphs affect their end behavior.
 <ul><li> Graph A: <m>f(x)=-11x^3+32+42x^2+x^4-64x</m> </li>
   <li> Graph B: <m>g(x)=2x^2+3-4x^3</m></li>
   <li> Graph C: <m>h(x)=x^7+2x^3-5x^2+2</m></li>
   <li> Graph D: <m>j(x)=3x^2-2x^4-5</m></li> 
-</ul>
+</ul></p>
 <sbsgroup>
   <sidebyside width="50%">
     <image>


### PR DESCRIPTION
Missing paragraph tags in [Activity 4.3.6](https://tbil.org/preview/precalculus/instructor/PR3.html#degree-and-leading-coefficient-of-polynomial-graphs) 