### PR TITLE
Fix header comment

### DIFF
--- a/xsl/slides.xsl
+++ b/xsl/slides.xsl
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- **********************************************************************-->
-<!-- Copyright 2012-2018                                                   -->
-<!-- Matthew Boelkins                                                      -->
-<!--                                                                       -->
-<!-- This file is part of Active Calculus.                                 -->
-<!--                                                                       -->
-<!-- Permission is granted to copy, distribute and/or modify this document -->
-<!-- under the terms of the Creative Commons BY-SA license.  The work      -->
-<!-- may be used for free by any party so long as attribution is given to  -->
-<!-- the author(s), the work and its derivatives are used in the spirit of -->
-<!-- "share and share alike".  All trademarks are the registered marks of  -->
-<!-- their respective owners.                                              -->
+<!-- This file includes code adapted from Active Calculus.                 -->
+<!-- https://github.com/active-calculus                                    -->
 <!-- **********************************************************************-->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">


### PR DESCRIPTION
Misleading header comment was copied over from the Active Calculus project, this more accurately describes the file as adapted from their code.

There's maybe a separate question about using CC-BY-SA-licensed code in our GPL-licensed project, but it's not clear to me that the Active Calculus code is properly licensed as CC-BY-SA since there are only comments in source files of this type that don't specify what version of the license, and no overall licensing information on the repository.  In any event, we are clearly following the directive to use it "in the spirit of share and share-alike".