### PR TITLE
Move hint

### DIFF
--- a/source/precalculus/source/08-TE/04.ptx
+++ b/source/precalculus/source/08-TE/04.ptx
@@ -1014,12 +1014,8 @@ p
       <p>
         State whether the Law of Sines or the Law of Cosines is the best choice to use to determine the indicated angle/side.
       </p>
-      <hint>
-      <p>
-        It might help to draw a picture!
-      </p>
-    </hint>
     </introduction>
+
 
     <task>
       <statement>
@@ -1027,6 +1023,11 @@ p
           Given <m>B=112</m><degree/>, <m>a=12</m>, and <m>b=25</m>, find <m>A</m>.
         </p>
       </statement>
+      <hint>
+      <p>
+        It might help to draw a picture!
+      </p>
+    </hint>
       <answer>
         <p>
           Law of Sines


### PR DESCRIPTION
There was a `<hint>` inside of the `<introduction>` of an `<activity>`, which built fine (but did not show up) in the HTML, but caused an exercise component mislabeled error in the PDF.

I tried moving it as a sibling of the `<introduction>`, but in this case both the HTML and PDF built fine but quietly did not display the hint.

Workaround here is to add it as a child of the first task, which should fix the build.