### PR TITLE
modify executables.ptx so pretext knows where to find Sage no matter what

### DIFF
--- a/.devcontainer/installSage.sh
+++ b/.devcontainer/installSage.sh
@@ -19,3 +19,6 @@ conda init
 echo 'conda activate sage' >> ~/.bashrc
 
 source ~/.bashrc
+
+export SAGE_PATH=$(which sage)
+echo "<executables sage=\"${SAGE_PATH}\"/>" > ./executables.ptx


### PR DESCRIPTION
Without this change, pretext-tools cannot run Sage (it doesn't run in an environment that's activated the conda environment)