### PR TITLE
Fix build

### DIFF
--- a/source/calculus/source/02-DF/04.ptx
+++ b/source/calculus/source/02-DF/04.ptx
@@ -82,12 +82,12 @@
                 <li><m>f(x)=(4)(x^5)</m></li>
                 <li><m>f(x)=x \ln x</m></li>
             </ol>
+        </statement>      
             <answer>
               <p>
                 B and C
               </p>
             </answer>
-        </statement>      
              
     </activity>
 

--- a/source/calculus/source/02-DF/07.ptx
+++ b/source/calculus/source/02-DF/07.ptx
@@ -68,22 +68,22 @@
       <task>
       <statement> 
         <p>Plug the point <m>(-3,-4)</m> into the expression found above for the derivative to get the slope of the tangent line.</p>
+          </statement>
           <answer>
             <p>
               <m>\dfrac{dy}{dx} = -\dfrac{3}{4}</m>
             </p>
           </answer>
-          </statement>
       </task>
       <task>
       <statement>
           <p>Use the value for the slope of the tangent line to obtain the equation of the tangent line.</p>
+          </statement>
           <answer>
             <p>
               <m>y = -\dfrac{3}{4}x-\dfrac{25}{4}</m>
             </p>
           </answer>
-          </statement>
       </task>
   </activity>
 


### PR DESCRIPTION
There were a few `<answer>`s that snuck inside of `<statement>`s, causing the PDF build to fail.

For future reference, these can be easily found by running the following command in the terminal:

`xpath -e '//answer[not(parent::activity or parent::task)]' source/*/source/*/*.ptx`

(Strictly speaking, that finds `<answer>`s whose parent is neither a `<activity>` or a `<task>`