### PR TITLE
PR7 Checkit bugfix

### DIFF
--- a/source/precalculus/exercises/outcomes/PR/PR7/generator.sage
+++ b/source/precalculus/exercises/outcomes/PR/PR7/generator.sage
@@ -107,7 +107,7 @@ class Generator(BaseGenerator):
         d = max(max(find_local_minimum(f(x),r2-2,r2-0.2)[0], find_local_minimum(f(x),r2+0.2,r2+2)[0])+2,10)
 
         #Plot curve, skipping over asymptote
-        P=plot(f(x), (a,b), ymin=c,ymax=d,detect_poles=True,aspect_ratio=1,gridlines=True,ticks=[int((d-c)/10),int((d-c)/10)])
+        P=plot(f(x), (a,b), ymin=c,ymax=d,detect_poles=True,aspect_ratio=1,gridlines=True,ticks=[2,int((d-c)/10)])
 
         #Undefined point
         P+=point((r1,f(r1)), markeredgecolor='red', color='white',size=22,zorder=15)


### PR DESCRIPTION
The plot command was trying to use the same tickmarks for the x and y axes.  However, the xmin and xmax were fixed from -10 to 10, while the y axis could vary based on the graph.  If the y axis was very tall, the size of the tickmarks was big, and then using that for the x-axis meant fewer than 2 tickmarks, which apparently raises an error.

Fix is to just set the xtickmarks to always be 2.

Closes #765 