### PR TITLE
Fixing errors introduced by #775

### DIFF
--- a/source/calculus/source/02-DF/02.ptx
+++ b/source/calculus/source/02-DF/02.ptx
@@ -412,7 +412,7 @@ The second derivative is the derivative of the derivative. It encodes informatio
                 <p>
                   Consider the following continuous function </p><me>
                     g(x) = \begin{cases}
-                      x + 2 \amp x \leq 2 \
+                      x + 2 \amp x \leq 2 \\
                       x^2   \amp x \gt  2
                     \end{cases}
                   </me>
@@ -439,7 +439,7 @@ The second derivative is the derivative of the derivative. It encodes informatio
                     Consider the following discontinuous function:
                     <me>
                         g(x) = \begin{cases}
-                        x + 2 \amp x \leq 2 \
+                        x + 2 \amp x \leq 2 \\
                         x   \amp x \gt  2
                         \end{cases}
                     </me>
@@ -466,7 +466,7 @@ The second derivative is the derivative of the derivative. It encodes informatio
                         Consider the following function
                         <me>
                             g(x) = \begin{cases}
-                            ax + 2 \amp x \leq 2 \
+                            ax + 2 \amp x \leq 2 \\
                             bx^2   \amp x \gt  2
                             \end{cases}
                         </me>

--- a/source/calculus/source/02-DF/05.ptx
+++ b/source/calculus/source/02-DF/05.ptx
@@ -355,9 +355,9 @@
                                 x = var('x')
                                 f = 2*sgn(x)
                                 p1 = plot(f,(x,-4,-0.05), gridlines=True,
-                                axes_labels=('$x$','$a(x)$'), thickness=2)
+                                    axes_labels=('$x$','$a(x)$'), thickness=2)
                                 p2 = plot(f,(x,.05,4), gridlines=True, axes_labels=('$x$','$a(x)$'),
-                                thickness=2)
+                                    thickness=2)
                                 c1 = circle((0,-2),0.05,fill=True,facecolor='white',thickness=1)
                                 c2 = circle((0,2),0.05, fill=True,facecolor='blue', thickness=1)
                                 p1+p2+c1+c2
@@ -367,9 +367,8 @@
                             <sageplot>
                                 x = var('x')
                                 f = -abs(x)+2
-                                p =
-                                plot(f,(x,-4,4),gridlines=True,thickness=2,axes_labels=('$x$','$b(x)$'),
-                                aspect_ratio=1)
+                                p = plot(f,(x,-4,4),gridlines=True,thickness=2,axes_labels=('$x$','$b(x)$'),
+                                    aspect_ratio=1)
                                 p
                             </sageplot>
                         </image>

--- a/source/calculus/source/02-DF/07.ptx
+++ b/source/calculus/source/02-DF/07.ptx
@@ -148,8 +148,7 @@
           <image width="70%">
             <sageplot>
               x = var('x')
-              p =
-              parametric_plot((cos(x)/(1+(sin(x))^2),(cos(x)*sin(x))/(1+(sin(x))^2)),(x,0,2*pi),thickness=2,axes_labels=('$x$','$y$'))
+              p = parametric_plot((cos(x)/(1+(sin(x))^2),(cos(x)*sin(x))/(1+(sin(x))^2)),(x,0,2*pi),thickness=2,axes_labels=('$x$','$y$'))
               p
             </sageplot>
           </image>


### PR DESCRIPTION
Closes #781 and #782. I found all the cases blocks with `\` instead of `\\` and fixed indentation on some long lines in sage blocks, which I did in a separate commit. The long lines were introduced by reckless use of the XML formatter. Not sure about the `\\`.
