### PR TITLE
Update 04.ptx for confusing x=

### DIFF
--- a/source/precalculus/source/01-EQ/04.ptx
+++ b/source/precalculus/source/01-EQ/04.ptx
@@ -81,11 +81,11 @@
         <statement>
         <p> What values on the number line could <m>x-7 </m> equal?
           <ol marker="A." cols="2">
-            <li><p><m>x=-7</m> </p></li>
-            <li><p> <m>x=-2</m> </p></li>
-            <li><p> <m>x=0</m> </p></li>
-            <li><p> <m>x=2</m></p></li>
-            <li><p> <m>x=7</m></p></li>
+            <li><p><m>-7</m> </p></li>
+            <li><p> <m>-2</m> </p></li>
+            <li><p> <m>0</m> </p></li>
+            <li><p> <m>2</m></p></li>
+            <li><p> <m>7</m></p></li>
         </ol> </p>
       </statement>
       <answer>


### PR DESCRIPTION
Deleting the x= on this activity's (Activity 1.4.3.) answers will help. All my teams today were confused by this, so I think this simple change will help.