### PR TITLE
Fix vector addition example in 03.ptx

### DIFF
--- a/source/linear-algebra/source/02-EV/03.ptx
+++ b/source/linear-algebra/source/02-EV/03.ptx
@@ -62,7 +62,7 @@
             <li><m>\left[\begin{array}{c}1\\2\\3\end{array}\right]+
             \left[\begin{array}{c}4\\5\\6\end{array}\right]</m></li>
             <li><m>\left[\begin{array}{c}1\\2\\3\end{array}\right]+
-            \left[\begin{array}{c}1\\1\\1\end{array}\right]</m></li>
+            \left[\begin{array}{c}1\\0\\-2\end{array}\right]</m></li>
             <li><m>-2\left[\begin{array}{c}1\\2\\3\end{array}\right]</m></li>
             </ol>
                 </p>


### PR DESCRIPTION
Currently all vectors are in the span since `[1 1 1]^T = 1/3 [4 5 6]^T - 1/3 [1 2 3]^T`