### PR TITLE
Remove "rank" to replace with "number of pivots" Update 07.ptx

### DIFF
--- a/source/linear-algebra/source/02-EV/07.ptx
+++ b/source/linear-algebra/source/02-EV/07.ptx
@@ -452,7 +452,7 @@ Prove that, for any column vector <m>\vec{b} = \left[\begin{array}{c}b_1\\b_2\\ 
     Prove that the columns of <m>M</m> form a basis for <m>\mathbb{R}^n</m>.</li>
 
 <li>
-    Prove that the rank of <m>M</m> is <m>n</m>.</li>
+    Prove that the reduced row echelon form of <m>M</m> has <m>n</m> pivots.</li>
 </ul>  
                 </p>
     </exploration>


### PR DESCRIPTION
changed "rank" to number of pivots in the math writing exploration