### PR TITLE
Update 07.ptx change marker label typo fix

### DIFF
--- a/source/linear-algebra/source/02-EV/07.ptx
+++ b/source/linear-algebra/source/02-EV/07.ptx
@@ -307,7 +307,7 @@ Find its solution space.
         <p>
 Which of these is the best choice of basis for this
 solution space?
-<ol marker="A" cols="3">
+<ol marker="A." cols="3">
     <li><m>\{\}</m></li>
     <li><m>\{\vec 0\}</m></li>
     <li>The basis does not exist</li>


### PR DESCRIPTION
Line 310 change from `ol marker="A" cols="3"` to `ol marker="A." cols="3"` to align with same notation for other ordered lists in section