### PR TITLE
Update 01.ptx 2 small typos

### DIFF
--- a/source/precalculus/source/07-PF/01.ptx
+++ b/source/precalculus/source/07-PF/01.ptx
@@ -95,7 +95,7 @@
               </row>
               <row bottom="minor">
                 <cell><m>\dfrac{5\pi}{4}</m></cell>
-                <cell><m>\dfrac{\sqrt{2}}{2}</m> </cell>
+                <cell><m>-\dfrac{\sqrt{2}}{2}</m> </cell>
                 <cell> </cell>               
               </row>
               <row bottom="minor">
@@ -395,7 +395,7 @@ P
     <definition xml:id="def-amplitude">
       <statement>
         <p>
-        The <term>amplitude</term> of a sine curve is vertical distance from the center of the curve to the maximum (or minimum) value. 
+        The <term>amplitude</term> of a sine curve is the vertical distance from the center of the curve to the maximum (or minimum) value. 
         </p> 
 
         <p>


### PR DESCRIPTION
A value in the chart in the graph of sine activity should've been negative, and the definition of amplitude was missing the word "the."