### PR TITLE
incorporating vector equations into AT3

### DIFF
--- a/source/linear-algebra/source/03-AT/03.ptx
+++ b/source/linear-algebra/source/03-AT/03.ptx
@@ -193,9 +193,11 @@ Let <m>T: \IR^3 \rightarrow \IR^2</m> be the linear transformation with the foll
         <p>
           In general, <m>\ker T</m> is the set of solutions to the equation:
           <me>
-            T\left(\vec{x}\right)=T\left(\left[\begin{array}{c}x_1\\x_2\\x_3\end{array}\right]\right)=\left[\begin{array}{c}0\\0\end{array}\right].
+            T\left(\vec{x}\right)=T\left(\left[\begin{array}{c}x_1\\x_2\\x_3\end{array}\right]\right)
+            =x_1\left[\begin{array}{c}\unknown\\\unknown\end{array}\right]
+            +x_2\left[\begin{array}{c}\unknown\\\unknown\end{array}\right]+x_3\left[\begin{array}{c}\unknown\\\unknown\end{array}\right]=\left[\begin{array}{c}0\\0\end{array}\right].
           </me>
-          Write down an equivalent <em>vector equation</em>, solve it, and describe <m>\ker T</m>. 
+          Complete and solve this vector equation to find <m>\ker T</m>. 
         </p>
       </statement>
     </task>


### PR DESCRIPTION
This is me taking another stab at the ideas expressed in #657. 

I have revised activity 3.3.5, added a remark just after, and revised activity 3.3.10 (which is 3.3.11 in the preview). 

My primary goal with this re-write is to address some instructional challenges our team has had in facilitating these discussions. First, we want our students to gain more experience in working with equations of the form T(x)=w and translating them into vector equations for analysis. 

Secondly, I've also structured these in a way that nudges students to do (a) more writing and (b) more deliberation of answers. For instance, I really want students to write out some of these vector equations and focus on this translation step before just plugging into the RREF-machine. I was also deliberate in 3.3.11 (a) to have a situation where there could plausibly be two different answers. 

Expecting more discussion on this, but wanted to share my process up front. 