### PR TITLE
updated 6.7.4 to make the location of the typical rectangle more clear.

### DIFF
--- a/source/calculus/source/06-AI/07.ptx
+++ b/source/calculus/source/06-AI/07.ptx
@@ -165,13 +165,13 @@
             <task>
                 <statement>
                     <p>
-                        Draw and label a horizontal rectangle across the middle of the plate of width <m> l_i</m>
-                        and height <m> x_i</m>. What is the area <m>A_i</m> of this rectangle?
+                        Draw and label a thin, horizontal rectangle across the middle of the plate of width <m> l_i</m>
+                        and height <m> \Delta x_i</m>. What is the area <m>A_i</m> of this rectangle?
                     </p>
                 </statement>
                 <answer>
                     <p>
-                        <m>A_i=l_ix_i</m>
+                        <m>A_i=l_i\Delta x_i</m>
                     </p>
                 </answer>
             </task>


### PR DESCRIPTION
When doing this activity in class, many teams misunderstood the intent and just drew the maximal size rectangle inside the entire trapezoid. This should make it clear that the height is very thin. 