### PR TITLE
Xpath wrapper script

### DIFF
--- a/scripts/xpath_wrapper.py
+++ b/scripts/xpath_wrapper.py
@@ -1,0 +1,49 @@
+import argparse
+import lxml.etree as ET
+
+def main(query:str, file:str,verbose=False):
+    tree = ET.parse(file)
+    results=tree.xpath(query)
+    if not results:
+        if verbose:
+            print(f"Scanning {file}...")
+            print(f"No results found")
+        return
+    print(f"Found in {file}:")
+    for result in results:
+        print(f"Line {result.sourceline}")
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Searches files for xml elements specified by the query')
+    parser.add_argument('files', nargs='*')
+    parser.add_argument('-q', '--query', help="Give an explicit xpath query. If present, overrides --element, --child, and --no-child")
+    parser.add_argument('-e', '--element', action='append',  help="Restricts search to specified elements")
+    parser.add_argument('-c', '--child', action='append',  help="Restricts search to elements who have a specified child element")
+    parser.add_argument('-n', '--no-child', action='append',  help="Restricts search to elements who do not have a specified child element")
+    parser.add_argument('-d', '--display-query',action='store_true', help="Display xpath query generate from --element, --child, and --no-child")
+    parser.add_argument('-v', '--verbose',action='store_true', help="Verbose mode")
+    args = parser.parse_args()
+
+    files=args.files
+ 
+    if args.query:
+        query=args.query
+        if args.element or args.child or args.no_child:
+            print("Applying --query and ignoring --element, --child, and --no-child")
+    else:
+        if not args.element:
+            print("Must specify --query or --element")
+            exit(1)
+        query='//*[(' + ' or '.join([f"self::{e}" for e in args.element])+')'
+        if args.child:
+          query+= 'and '+' and '.join([f"child::{c}" for c in args.child])
+        if args.no_child:
+          query+= 'and '+' and '.join([f"not(child::{c})" for c in args.no_child])
+        query+=']'
+        if args.verbose or args.display_query:
+            print(f"Applying query {query}")
+
+    for file in files:
+        main(query=query, file=file,verbose=args.verbose)


### PR DESCRIPTION
Closes #903 .  I don't know if this is the "right" solution, but I tried to write this in a way that it could be adapted to apply to #764 .  

Example usages:

```
root@773dafec85fa:/workspaces/library $ python scripts/xpath_wrapper.py --element image --element interactive --no-child description  source/linear-algebra/source/*/*.ptx --display-query
Applying query //*[(self::image or self::interactive)and not(child::description)]
Found in source/linear-algebra/source/01-LE/02.ptx:
Line 336
Found in source/linear-algebra/source/02-EV/02.ptx:
Line 45
Line 65
Line 111
Line 158
Found in source/linear-algebra/source/02-EV/04.ptx:
Line 87
Found in source/linear-algebra/source/03-AT/01.ptx:
Line 86
Line 121
Found in source/linear-algebra/source/03-AT/03.ptx:
Line 95
Line 259
Found in source/linear-algebra/source/03-AT/04.ptx:
Line 47
Line 202
Line 411
Line 487
Line 712
Found in source/linear-algebra/source/04-MX/01.ptx:
Line 47
Found in source/linear-algebra/source/05-GT/01.ptx:
Line 48
Line 65
Line 101
Line 150
Line 184
Line 228
Line 269
Line 300
Line 318
Line 343
Line 416
Line 463
Line 571
Found in source/linear-algebra/source/05-GT/02.ptx:
Line 59
Found in source/linear-algebra/source/05-GT/03.ptx:
Line 86
Line 133
Line 167
Found in source/linear-algebra/source/applications/pagerank.ptx:
Line 19
Line 89
Line 130
Line 219
Line 288
Line 347
Line 405
Line 450
Found in source/linear-algebra/source/applications/truss.ptx:
Line 14
Line 18
Line 37
Line 68
Line 88
Line 117
Line 248
Line 266
Line 294
Line 323
Line 358
Line 462
```

```
root@773dafec85fa:/workspaces/library $ python scripts/xpath_wrapper.py --query '//*[(self::image or self::interactive) and not(child::description)]' source/linear-algebra/source/02-EV/*.ptx
Found in source/linear-algebra/source/02-EV/02.ptx:
Line 45
Line 65
Line 111
Line 158
Found in source/linear-algebra/source/02-EV/04.ptx:
Line 87
```
