### PR TITLE
Updated Activities 6.5.14 and 6.5.20.

### DIFF
--- a/source/calculus/source/06-AI/05.ptx
+++ b/source/calculus/source/06-AI/05.ptx
@@ -375,8 +375,9 @@
         
         <activity xml:id="activity-A4pyramidmass">
             <introduction>
-                Consider a pyramid with a <m>8\times 8</m> ft square base and a height of 16 feet.  Suppose the density of the pyramid is <m>\delta(h)=10+\cos(\pi h)</m> lb/ft<m>^3</m> where <m>h</m> is the height in feet.
-            
+                <p>
+                    Consider a pyramid with an <m>8\times 8</m> ft square base and a height of 16 feet.  Suppose the density of the pyramid is <m>\delta(h)=10+\cos(\pi h)</m> lb/ft<m>^3</m> where <m>h</m> is the height in feet.
+                </p>        
             </introduction>
             
             <task>
@@ -485,7 +486,7 @@
         <activity xml:id="activity-TI4pyramidcentermass">
             <statement>
                 <p>
-                    Consider that for the pyramid from <xref ref="activity-A4pyramidmass"/>, a cross section of height <m>h</m> is <m>A(h)=\pi\cdot \left( \frac{16-h}{2}\right)^2</m> ft<m>^2</m>.  Also recall that the density of the pyramid is <m>\delta(h)=10+\cos{\pi h}</m> lb/feet<m>^3</m>, where <m>h</m> is the height in feet, and that we found the total mass to be about 3414.14.6  lb.
+                    Consider that for the pyramid from <xref ref="activity-A4pyramidmass"/>, a cross section of height <m>h</m> is <m>A(h)=\left( \frac{16-h}{2}\right)^2</m> ft<m>^2</m>.  Also recall that the density of the pyramid is <m>\delta(h)=10+\cos{\pi h}</m> lb/ft<m>^3</m>, where <m>h</m> is the height in feet, and that we found the total mass to be about 3414.14  lb.
                 </p>
                 <p>
                     Use <xref ref="fact-AI4centerofmass"/> to find the height where the center of mass occurs.


### PR DESCRIPTION
I found a typo in the latter activity for the 3414.14 number. Then I realized that the A(h) needed a pi removed (it's a square not a disk). Then I fixed the former activity which was missing a `<p> `tag.