### PR TITLE
Print book support

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -142,6 +142,15 @@
       output-filename="TBIL-Linear-Algebra-Slides.pdf" >
       <stringparams debug.project.number="the-way-it-should-be"/>
     </target>
+    <!-- For printing by 619 Wreath-->
+    <target
+      name="linear-algebra-print-619"
+      format="pdf"
+      source="linear-algebra/source/main.ptx"
+      publication="publication-619.ptx"
+      output-filename="TBIL-Linear-Algebra-619.pdf" >
+      <stringparams debug.project.number="the-way-it-should-be"/>
+    </target>
 
   </targets>
 </project>

--- a/publication/instructor.ptx
+++ b/publication/instructor.ptx
@@ -35,7 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
-    <version include="instructor nonpreview instructor-nonpreview"/>
+    <version include="instructor nonpreview instructor-nonpreview html"/>
   </source>
 
   <numbering>

--- a/publication/preview.ptx
+++ b/publication/preview.ptx
@@ -35,7 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
-    <version include="instructor preview"/>
+    <version include="instructor preview html"/>
   </source>
 
   <numbering>

--- a/publication/publication-619.ptx
+++ b/publication/publication-619.ptx
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This is the publication file for a newly generated PreTeXt book.     -->
+<!-- By changing the values of attributes here, you can change how        -->
+<!-- the output looks and functions.  For the complete documentation      -->
+<!-- of publication-file options, see                                     -->
+<!-- https://pretextbook.org/doc/guide/html/publisher-file-reference.html -->
+
+<publication>
+  <common>
+    <!-- Level at which are html files generated (chapter/section/etc): -->
+    <chunking level="2" />
+    <!-- Depth for table of contents.  0 means no TOC -->
+    <tableofcontents level="2" />
+    <!-- Visibility of exercise components where they first appear.          -->
+    <!-- There are four components (statement/hint/answer/solution) for each -->
+    <!-- of five exercise types (inline/divisional/worksheet/reading/        -->
+    <!-- project). Some examples:                                            -->
+    <exercise-inline statement="yes" hint="yes" answer="no" solution="no" />
+    <exercise-divisional statement="yes" hint="yes" />
+    <exercise-project statement="yes" hint="yes" answer="no" solution="no" />
+    <!-- Style of fill-in-the-blanks: -->
+    <fillin textstyle="underline" mathstyle="shade" />
+    <!-- You can set a watermark: -->
+    <!-- <watermark scale="0.5">DRAFT</watermark> -->
+  </common>
+
+
+  <!-- Set where external assets and generated assets will be   -->
+  <!-- stored or created.  Directories are relative to the main -->
+  <!-- source PreTeXt file                                      -->
+  <source>
+    <directories external="../../../assets" generated="../generated-assets" />
+    <!-- Set which marked elements are included in this version: -->
+    <!-- See
+    https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
+    <!-- <version include="videos labs"/> -->
+    <version include="main nonpreview"/> 
+  </source>
+
+  <numbering>
+    <!-- the divisions element describes the numbering of divisions.  -->
+    <!-- @part-structure should be "decorative" or "structural",      -->
+    <!-- were the latter would restart numbering chapters within each -->
+    <!-- part (this only matters if your book has parts).             -->
+    <!-- The attribute @chapter-start give the number of the first    -->
+    <!-- chapter.  @level says how deep (chapter->section->subsection)-->
+    <!-- numbering should appear.                                     -->
+    <!-- For use with a book organized by part, you can set the -->
+    <!--  @part-structure to "decorative" or "structural" -->
+    <!-- <divisions part-structure="decorative" chapter-start="1" level="3"/> -->
+    <!-- The next elements say how the levels deep to break up the    -->
+    <!-- numbering of the respective elements. Can't be more than the -->
+    <!-- @level on divisions above.                                   -->
+    <blocks level="2" />
+    <projects level="2" />
+    <equations level="2" />
+    <footnotes level="2" />
+  </numbering>
+
+  <!-- LaTeX specific options: set @print="yes" to get pdf set up   -->
+  <!-- for printing; set @sides="two" if the printing woudl be two- -->
+  <!-- sided.  @pageref="yes/no" controls whether page number are   -->
+  <!-- included in cross-references                                 -->
+  <latex print="yes" font-size="12" draft="no">
+    <page>
+      <geometry>papersize={6in,9in},margin=1in</geometry>
+    </page>
+    <asymptote links="no" />
+
+  </latex>
+
+  <html>
+    <platform host="web"/>
+    <!-- The host above could also be "runestone" -->
+
+    <!-- Whether to knowl a particular elements is set here    -->
+    <!-- Lots of elements have this possibility; see the guide -->
+    <knowl
+      theorem="no"
+      proof="yes"
+      definition="no"
+      example="no"
+      example-solution="yes"
+      project="no"
+      task="no"
+      remark="no"
+      objectives="no"
+      outcomes="no"
+      figure="no"
+      table="no"
+      listing="no"
+      list="no"
+      exercise-inline="yes"
+      exercise-divisional="no"
+      exercise-worksheet="no"
+      exercise-readingquestion="no"
+    />
+    
+    <css theme="denver" palette="leaves"/>
+    <!-- Search can be default or none, or you can use a Google-cx number to use google's search
+    feature (but then variant should be set to none to avoid conflict) -->
+    <search variant="default" />
+    <!-- Embedded calculators.  For math, this could be geogebra-classic, geogebra-graphing,
+    geogebra-geometry, and geogebra-3d.  For ActiveCode, you can specify a language (python,
+    javascript, etc).  -->
+    <calculator model="none" activecode="none" />
+    <!-- Set the base URL of where the online version is hosted to have links in other formats -->
+    <baseurl href="https://tbil.org"/>
+    <!-- Control behavior of online WeBWorK, per type: -->
+    <webwork
+      inline="dynamic"
+      divisional="static"
+      reading="static"
+      worksheet="static"
+      project="dynamic"
+    />
+    <!-- Magic IDs identify HTML pages to analytics services   -->
+    <!-- Presence implies relevant Javascript will be added    -->
+    <!-- StatCounter requires both values to be set            -->
+    <!-- <analytics google-gst="UA-0123456-1" statcounter-project="0123456"
+    statcounter-security="0123456"/> -->
+  </html>
+
+  <!-- To use WeBWorK, you need a server.  -->
+  <!-- <webwork server="https://webwork-ptx.aimath.org"> -->
+</publication>

--- a/publication/publication-619.ptx
+++ b/publication/publication-619.ptx
@@ -64,7 +64,7 @@
   <!-- included in cross-references                                 -->
   <latex print="yes" font-size="12" draft="no">
     <page>
-      <geometry>papersize={6in,9in},margin=1in</geometry>
+      <geometry>papersize={7in,10in},margin=1in</geometry>
     </page>
     <asymptote links="no" />
 

--- a/publication/publication-619.ptx
+++ b/publication/publication-619.ptx
@@ -35,7 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
-    <version include="main nonpreview"/> 
+    <version include="main nonpreview print"/> 
   </source>
 
   <numbering>

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -35,7 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
-    <version include="main nonpreview"/> 
+    <version include="main nonpreview html"/> 
   </source>
 
   <numbering>

--- a/source/common/authors/lewis.ptx
+++ b/source/common/authors/lewis.ptx
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <author xmlns:xi="http://www.w3.org/2001/XInclude">
     <personname>Drew Lewis</personname>
+    <institution>Center for Grading Reform</institution>
     <email>drew.lewis@gmail.com</email>
 </author>

--- a/source/linear-algebra/source/01-LE/01.ptx
+++ b/source/linear-algebra/source/01-LE/01.ptx
@@ -1016,7 +1016,7 @@ Augmented matrix:
                         <li>For <m>a,b, \in \mathbb{R}</m>, <m>a \sim b</m> if an only if <m>|a|=|b|</m>.</li>
                         </ul></p></statement></exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-LE1"/>.

--- a/source/linear-algebra/source/01-LE/01.ptx
+++ b/source/linear-algebra/source/01-LE/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="LE1" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Linear Systems, Vector Equations, and Augmented Matrices (LE1)</title>
+    <title component="html">Linear Systems, Vector Equations, and Augmented Matrices (LE1)</title>
+    <title component="print">Linear Systems and Vector Equations</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -944,7 +944,7 @@ rref(A)
             </statement></exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-LE2"/>.

--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="LE2" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Row Reduction of Matrices (LE2)</title>
+    <title component="html">Row Reduction of Matrices (LE2)</title>
+    <title component="print">Row Reduction of Matrices</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/01-LE/03.ptx
+++ b/source/linear-algebra/source/01-LE/03.ptx
@@ -474,7 +474,7 @@ different solutions. We'll learn how to find such solution sets in
                     </statement>
                 </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-LE3"/>.

--- a/source/linear-algebra/source/01-LE/03.ptx
+++ b/source/linear-algebra/source/01-LE/03.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="LE3" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Counting Solutions for Linear Systems (LE3)</title>
+    <title component="html">Counting Solutions for Linear Systems (LE3)</title>
+    <title component="print">Counting Solutions for Linear Systems</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/01-LE/04.ptx
+++ b/source/linear-algebra/source/01-LE/04.ptx
@@ -437,7 +437,7 @@ Explain how to describe this solution set using set notation.
 <li> Suppose that a linear system has five equations and three unknowns and that the coefficient matrix has a pivot in every column. Then the linear system is consistent and has a unique solution.</li></ul></p></statement></exploration>
     </subsection>    
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-LE4"/>.

--- a/source/linear-algebra/source/01-LE/04.ptx
+++ b/source/linear-algebra/source/01-LE/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="LE4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Linear Systems with Infinitely-Many Solutions (LE4)</title>
+    <title component="print">Linear Systems with Infinitely Many Solutions (LE4)</title>
+    <title component="html">Linear Systems with Infinitely Many Solutions</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/01-LE/main.ptx
+++ b/source/linear-algebra/source/01-LE/main.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <chapter xml:id="LE" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Systems of Linear Equations (LE)</title>
+    <title component="html">Systems of Linear Equations (LE)</title>
+    <title component="print">Systems of Linear Equations</title>
     <xi:include href="outcomes/main.ptx"/>
     <xi:include href="./readiness.ptx"/>
     <xi:include href="01.ptx"/>

--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -579,7 +579,7 @@ We can do this in a few parts. I've used bullets here to indicate all that needs
                     </statement>
     </exploration>
 </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV1"/>.

--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV1" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Linear Combinations (EV1)</title>
+    <title component="html">Linear Combinations (EV1)</title>
+    <title component="print">Linear Combinations</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/02.ptx
+++ b/source/linear-algebra/source/02-EV/02.ptx
@@ -556,7 +556,7 @@ Given no additional information about the vectors <m>\vec{v}_1,\dots, \vec{v}_m<
         </p>
     </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV2"/>.

--- a/source/linear-algebra/source/02-EV/02.ptx
+++ b/source/linear-algebra/source/02-EV/02.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV2" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Spanning Sets (EV2)</title>
+    <title component="html">Spanning Sets (EV2)</title>
+    <title component="print">Spanning Sets</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/03.ptx
+++ b/source/linear-algebra/source/02-EV/03.ptx
@@ -1113,7 +1113,7 @@ Is it possible that there is a subset of <m>V</m> containing fewer vectors than 
 </p></exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV3"/>.

--- a/source/linear-algebra/source/02-EV/03.ptx
+++ b/source/linear-algebra/source/02-EV/03.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV3" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Subspaces (EV3)</title>
+    <title component="html">Subspaces (EV3)</title>
+    <title component="print">Subspaces</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/04.ptx
+++ b/source/linear-algebra/source/02-EV/04.ptx
@@ -651,7 +651,7 @@ vectors that can form a linearly independent set?
     </exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV4"/>.

--- a/source/linear-algebra/source/02-EV/04.ptx
+++ b/source/linear-algebra/source/02-EV/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Linear Independence (EV4)</title>
+    <title component="html">Linear Independence (EV4)</title>
+    <title component="print">Linear Independence</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/05.ptx
+++ b/source/linear-algebra/source/02-EV/05.ptx
@@ -599,7 +599,7 @@ Must a basis for the space <m>P_2</m>, the space of all quadratic polynomials, c
     </exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV5"/>.

--- a/source/linear-algebra/source/02-EV/05.ptx
+++ b/source/linear-algebra/source/02-EV/05.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV5" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Identifying a Basis (EV5)</title>
+    <title component="html">Identifying a Basis (EV5)</title>
+    <title component="print">Identifying a Basis</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/06.ptx
+++ b/source/linear-algebra/source/02-EV/06.ptx
@@ -477,7 +477,7 @@ Thus the basis for a subspace is not unique in general.
         </p></exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV6"/>.

--- a/source/linear-algebra/source/02-EV/06.ptx
+++ b/source/linear-algebra/source/02-EV/06.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV6" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Subspace Basis and Dimension (EV6)</title>
+    <title component="html">Subspace Basis and Dimension (EV6)</title>
+    <title component="print">Subspace Basis and Dimension</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/07.ptx
+++ b/source/linear-algebra/source/02-EV/07.ptx
@@ -457,7 +457,7 @@ Prove that, for any column vector <m>\vec{b} = \left[\begin{array}{c}b_1\\b_2\\ 
                 </p>
     </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-EV7"/>.

--- a/source/linear-algebra/source/02-EV/07.ptx
+++ b/source/linear-algebra/source/02-EV/07.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="EV7" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Homogeneous Linear Systems (EV7)</title>
+    <title component="html">Homogeneous Linear Systems (EV7)</title>
+    <title component="print">Homogeneous Linear Systems</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/02-EV/main.ptx
+++ b/source/linear-algebra/source/02-EV/main.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <chapter xml:id="EV" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Euclidean Vectors (EV)</title>
+    <title component="html">Euclidean Vectors (EV)</title>
+    <title component="print">Euclidean Vectors</title>
     <xi:include href="outcomes/main.ptx"/>
     <xi:include href="readiness.ptx"/>
     <xi:include href="01.ptx"/>

--- a/source/linear-algebra/source/03-AT/01.ptx
+++ b/source/linear-algebra/source/03-AT/01.ptx
@@ -787,7 +787,7 @@ and <m>T(cf(x))=cT(f(x))</m>.
     </exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT1"/>.

--- a/source/linear-algebra/source/03-AT/01.ptx
+++ b/source/linear-algebra/source/03-AT/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT1" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Linear Transformations (AT1)</title>
+    <title component="html">Linear Transformations (AT1)</title>
+    <title component="print">Linear Transformations</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/02.ptx
+++ b/source/linear-algebra/source/03-AT/02.ptx
@@ -582,7 +582,7 @@ Prove that each transformation is linear, and that your matrix representations a
                 </p>
     </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT2"/>.

--- a/source/linear-algebra/source/03-AT/02.ptx
+++ b/source/linear-algebra/source/03-AT/02.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT2" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Standard Matrices (AT2)</title>
+    <title component="html">Standard Matrices (AT2)</title>
+    <title component="print">Standard Matrices</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/03.ptx
+++ b/source/linear-algebra/source/03-AT/03.ptx
@@ -816,7 +816,7 @@ Let <m>\{\vec{v_1},\vec{v_2},\ldots,\vec{v_n}\}</m> be a set of vectors in <m>V<
                 </p>
     </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT3"/>.

--- a/source/linear-algebra/source/03-AT/03.ptx
+++ b/source/linear-algebra/source/03-AT/03.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT3" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Image and Kernel (AT3)</title>
+    <title component="html">Image and Kernel (AT3)</title>
+    <title component="print">Image and Kernel</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/04.ptx
+++ b/source/linear-algebra/source/03-AT/04.ptx
@@ -1117,7 +1117,7 @@ Prove that <m>V</m> is isomorphic to<m>V^*</m>. Here are some things to think ab
     </ul>
      </p></statement></exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT4"/>.

--- a/source/linear-algebra/source/03-AT/04.ptx
+++ b/source/linear-algebra/source/03-AT/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Injective and Surjective Linear Maps (AT4)</title>
+    <title component="html">Injective and Surjective Linear Maps (AT4)</title>
+    <title component="print">Injective and Surjective Linear Maps</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/05.ptx
+++ b/source/linear-algebra/source/03-AT/05.ptx
@@ -738,7 +738,7 @@ for <em>all</em> <m>c\in \IR,\, (x_1,y_1),(x_2,y_2) \in V</m>.
                     <p>Consider the vector space of polynomials, <m>\P_n</m>. Suppose further that <m> n= ab</m>, where <m>a \mbox{ and } b</m> are each positive integers. Conjecture a relationship between <m>M_{a,b}</m> and <m>\P_n</m>. We will investigate this further in section <xref ref="AT6"></xref>
                     </p></statement></exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT5"/>.

--- a/source/linear-algebra/source/03-AT/05.ptx
+++ b/source/linear-algebra/source/03-AT/05.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT5" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Vector Spaces (AT5)</title>
+    <title component="html">Vector Spaces (AT5)</title>
+    <title component="print">Vector Spaces</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/06.ptx
+++ b/source/linear-algebra/source/03-AT/06.ptx
@@ -584,7 +584,7 @@ If you are given the values of <m>a,b,</m> and <m>c</m>, what value of <m>d</m> 
     </exploration>
     </subsection>
     
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-AT6"/>.

--- a/source/linear-algebra/source/03-AT/06.ptx
+++ b/source/linear-algebra/source/03-AT/06.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="AT6" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Polynomial and Matrix Spaces (AT6)</title>
+    <title component="html">Polynomial and Matrix Spaces (AT6)</title>
+    <title component="print">Polynomial and Matrix Spaces</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/03-AT/main.ptx
+++ b/source/linear-algebra/source/03-AT/main.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <chapter xml:id="AT" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Algebraic Properties of Linear Maps (AT)</title>
+    <title component="html">Algebraic Properties of Linear Maps (AT)</title>
+    <title component="print">Algebraic Properties of Linear Maps</title>
     <xi:include href="outcomes/main.ptx"/>
     <xi:include href="readiness.ptx"/>
     <xi:include href="01.ptx"/>

--- a/source/linear-algebra/source/04-MX/01.ptx
+++ b/source/linear-algebra/source/04-MX/01.ptx
@@ -392,7 +392,7 @@ Use the included map in this problem.
                 </statement>
      </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-MX1"/>.

--- a/source/linear-algebra/source/04-MX/01.ptx
+++ b/source/linear-algebra/source/04-MX/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="MX1" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Matrices and Multiplication (MX1)</title>
+    <title component="html">Matrices and Multiplication (MX1)</title>
+    <title component="print">Matrices and Multiplication</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/04-MX/02.ptx
+++ b/source/linear-algebra/source/04-MX/02.ptx
@@ -545,7 +545,7 @@ Is the matrix <m>\left[\begin{array}{ccc} 2 &amp; 3 &amp; 1 \\ -1 &amp; -4 &amp;
          </exploration>
      
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-MX2"/>.

--- a/source/linear-algebra/source/04-MX/02.ptx
+++ b/source/linear-algebra/source/04-MX/02.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="MX2" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>The Inverse of a Matrix (MX2)</title>
+    <title component="html">The Inverse of a Matrix (MX2)</title>
+    <title component="print">The Inverse of a Matrix</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/04-MX/03.ptx
+++ b/source/linear-algebra/source/04-MX/03.ptx
@@ -274,7 +274,7 @@ Video coming soon to
     </subsection>
 
 
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-MX3"/>.

--- a/source/linear-algebra/source/04-MX/03.ptx
+++ b/source/linear-algebra/source/04-MX/03.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="MX3" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Change of Basis (MX3)</title>
+    <title component="html">Change of Basis (MX3)</title>
+    <title component="print">Change of Basis</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/04-MX/04.ptx
+++ b/source/linear-algebra/source/04-MX/04.ptx
@@ -402,7 +402,7 @@ If you and a teammate were to do this independently, would you necessarily come 
         </p>
     </subsection>
   
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-MX4"/>.

--- a/source/linear-algebra/source/04-MX/04.ptx
+++ b/source/linear-algebra/source/04-MX/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="MX4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Row Operations as Matrix Multiplication (MX4)</title>
+    <title component="html">Row Operations as Matrix Multiplication (MX4)</title>
+    <title component="print">Row Operations as Matrix Multiplication</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/04-MX/main.ptx
+++ b/source/linear-algebra/source/04-MX/main.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <chapter xml:id="MX" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Matrices (MX)</title>
+    <title component="html">Matrices (MX)</title>
+    <title component="print">Matrices</title>
     <xi:include href="outcomes/main.ptx"/>
     <xi:include href="readiness.ptx"/>
     <xi:include href="01.ptx"/>

--- a/source/linear-algebra/source/05-GT/01.ptx
+++ b/source/linear-algebra/source/05-GT/01.ptx
@@ -1141,7 +1141,7 @@ Or we may use a formula:
                 </statement>
      </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-GT1"/>.

--- a/source/linear-algebra/source/05-GT/01.ptx
+++ b/source/linear-algebra/source/05-GT/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="GT1" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Row Operations and Determinants (GT1)</title>
+    <title component="html">Row Operations and Determinants (GT1)</title>
+    <title component="print">Row Operations and Determinants</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/05-GT/02.ptx
+++ b/source/linear-algebra/source/05-GT/02.ptx
@@ -493,7 +493,7 @@ Based on the previous activities, which technique is easier for computing determ
                 
      </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-GT2"/>.

--- a/source/linear-algebra/source/05-GT/02.ptx
+++ b/source/linear-algebra/source/05-GT/02.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="GT2" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Computing Determinants (GT2)</title>
+    <title component="html">Computing Determinants (GT2)</title>
+    <title component="print">Computing Determinants</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/05-GT/03.ptx
+++ b/source/linear-algebra/source/05-GT/03.ptx
@@ -416,7 +416,7 @@ Set this characteristic polynomial equal to zero and factor to determine the eig
                 </statement>
      </exploration>
     </subsection>
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-GT3"/>.

--- a/source/linear-algebra/source/05-GT/03.ptx
+++ b/source/linear-algebra/source/05-GT/03.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="GT3" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Eigenvalues and Characteristic Polynomials (GT3)</title>
+    <title component="html">Eigenvalues and Characteristic Polynomials (GT3)</title>
+    <title component="print">Eigenvalues and Characteristic Polynomials</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/05-GT/04.ptx
+++ b/source/linear-algebra/source/05-GT/04.ptx
@@ -177,7 +177,7 @@ associated with the eigenvalue <m>2</m>.
                 </statement>
      </exploration>
     </subsection>    
-    <subsection>
+    <subsection component="html">
         <title>Sample Problem and Solution</title>
         <p>
             Sample problem <xref ref="sample-GT4"/>.

--- a/source/linear-algebra/source/05-GT/04.ptx
+++ b/source/linear-algebra/source/05-GT/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="GT4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Eigenvectors and Eigenspaces (GT4)</title>
+    <title component="html">Eigenvectors and Eigenspaces (GT4)</title>
+    <title component="print">Eigenvectors and Eigenspaces</title>
     <objectives>
         <ul>
             <li>

--- a/source/linear-algebra/source/05-GT/main.ptx
+++ b/source/linear-algebra/source/05-GT/main.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <chapter xml:id="GT" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Geometric Properties of Linear Maps (GT)</title>
+    <title component="html">Geometric Properties of Linear Maps (GT)</title>
+    <title component="print">Geometric Properties of Linear Maps</title>
     <xi:include href="outcomes/main.ptx"/>
     <xi:include href="readiness.ptx"/>
     <xi:include href="01.ptx"/>

--- a/source/linear-algebra/source/meta/backmatter.ptx
+++ b/source/linear-algebra/source/meta/backmatter.ptx
@@ -3,11 +3,8 @@
   <title>Back Matter</title>
 
     <xi:include href="../applications/main.ptx"/>
-    <appendix xml:id="appendix-extras">
-        <title>Appendix</title>
-        <xi:include href="sample-exercises.ptx"/>
-        <xi:include href="definitions.ptx"/>
-    </appendix>
+    <xi:include href="sample-exercises.ptx"/>
+    <xi:include href="definitions.ptx"/>
 
     <index>
         <title>Index</title>

--- a/source/linear-algebra/source/meta/definitions.ptx
+++ b/source/linear-algebra/source/meta/definitions.ptx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<section xml:id="list-of-definitions" xmlns:xi="http://www.w3.org/2001/XInclude">
+<section xml:id="list-of-definitions" xmlns:xi="http://www.w3.org/2001/XInclude" component="html">
       <title>Definitions</title>
       <list-of elements="definition" divisions="section" empty="no" />
 </section>

--- a/source/linear-algebra/source/meta/definitions.ptx
+++ b/source/linear-algebra/source/meta/definitions.ptx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<section xml:id="list-of-definitions" xmlns:xi="http://www.w3.org/2001/XInclude" component="html">
+<appendix xml:id="list-of-definitions" xmlns:xi="http://www.w3.org/2001/XInclude" component="html">
       <title>Definitions</title>
       <list-of elements="definition" divisions="section" empty="no" />
-</section>
+</appendix>

--- a/source/linear-algebra/source/meta/sample-exercises.ptx
+++ b/source/linear-algebra/source/meta/sample-exercises.ptx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<section xml:id="sample-exercises" xmlns:xi="http://www.w3.org/2001/XInclude">
+<appendix xml:id="sample-exercises" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Sample Exercises with Solutions</title>
     <p>
 Here we model one exercise and solution for each learning objective.
@@ -38,4 +38,4 @@ for a complete solution.
 <xi:include href="../05-GT/samples/02.ptx"/>
 <xi:include href="../05-GT/samples/03.ptx"/>
 <xi:include href="../05-GT/samples/04.ptx"/>
-    </section>
+</appendix>


### PR DESCRIPTION
Various changes being made to support the publication of the print version of Linear Algebra.  This sets up a publication file, target, and appropriate components for when print and HTML content need to diverge.  It also closes #956 by shortening some titles and removing the abbreviations from them in the print version.