### PR TITLE
Make sagecells html only

### DIFF
--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -859,9 +859,9 @@ rref(A)
     </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
-<sage language="octave">
+<sage language="octave" component="html">
     <input>
 format rat
 

--- a/source/linear-algebra/source/01-LE/03.ptx
+++ b/source/linear-algebra/source/01-LE/03.ptx
@@ -111,7 +111,7 @@ How many solutions must this system have?
   </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 <input>
 A = [ 3 -2 13  6
       2 -2 10  2
@@ -182,7 +182,7 @@ How many solutions must this system have?
   </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 <input>rref([3,-2,13,6;2,-2,10,2;-1,0,-3,1;3,7,0,-2])</input>
 </sage>
 
@@ -251,7 +251,7 @@ How many solutions must this system have?
   </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <fact xml:id="LE3-fact-scenarios">
@@ -399,7 +399,7 @@ different solutions. We'll learn how to find such solution sets in
     </task>
   </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
     </subsection>
 

--- a/source/linear-algebra/source/01-LE/04.ptx
+++ b/source/linear-algebra/source/01-LE/04.ptx
@@ -188,7 +188,7 @@ in the following set-builder notation.
     </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 

--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -182,7 +182,7 @@ we refer to this real number as a <term>scalar</term>.
       </p>
   </task>
   <task>
-      <p>
+      <p component="html">
     Correct the SageMath code cell below to generate
     an illustration of several vectors belonging to
     <me>\vspan\left\{\left[\begin{array}{c}1\\2\end{array}\right],
@@ -191,43 +191,53 @@ we refer to this real number as a <term>scalar</term>.
      b\left[\begin{array}{c}-1\\1\end{array}\right]}{a, b \in \IR}</me>
     in the <m>xy</m> plane.
     </p>
-    <sage>
+    <sage component="html">
       <input>
 <xi:include href="./code/ev1-planar-span.sage" parse="text" />
       </input>
     </sage>
-    <p>
+    <p component="html">
     Based on this illustration, which of these geometrical objects
     best describes the span of these two vectors?
+    </p>
+    <p component="print">
+    Which of these geometrical objects
+    best describes the span of these two vectors?
+    </p>
     <ol marker="A." cols="4">
       <li>A line</li>
       <li>A plane</li>
       <li>A parabola</li>
       <li>A circle</li>
     </ol>
-      </p>
   </task>
 </activity>
 
 <activity estimated-time='5'>
     <statement>
-        <p>
+        <p component="html">
     Sketch a representation of all the vectors belonging to
     <m>\vspan\left\{\left[\begin{array}{c}6\\-4\end{array}\right],
      \left[\begin{array}{c}-3\\2\end{array}\right]\right\}</m>
     in the <m>xy</m> plane, or adapt the code in the previous
     activity to illustrate this span.
       </p>
+        <p component="print">
+    Sketch a representation of all the vectors belonging to
+    <m>\vspan\left\{\left[\begin{array}{c}6\\-4\end{array}\right],
+     \left[\begin{array}{c}-3\\2\end{array}\right]\right\}</m>
+    in the <m>xy</m> plane.
+    </p>
       <p>
     Which of these geometrical objects
     best describes the span of these two vectors?
-    <ol marker="A.">
+      </p>
+    <ol marker="A." cols="4">
       <li>A line</li>
       <li>A plane</li>
       <li>A parabola</li>
       <li>A cube</li>
     </ol>
-        </p>
     </statement>
 </activity>
 
@@ -286,7 +296,7 @@ x_3\left[\begin{array}{c}1\\0\\-3\end{array}\right]=0</m>
   </task>
 </activity>
 
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 
     <observation>
             <p>
@@ -351,7 +361,7 @@ The following are all equivalent statements:
         </answer> -->
 </activity>
 
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 
  <activity estimated-time="10">
     <introduction>
@@ -376,7 +386,7 @@ The following are all equivalent statements:
         </answer> -->
   </activity>
 
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 
 <!-- <activity estimated-time='10'>
     <introduction>
@@ -497,10 +507,11 @@ b\left[\begin{array}{c} 1 \\ 2 \\ 1 \end{array}\right]
 a,b\in\IR
 }
 </me>
-is a set containing infinitely-many vectors. See the below
+is a set containing infinitely-many vectors. </p>
+<p component="html">See the below
 Sage cell for an illustration.
   </p>
-<sage language="sage">
+<sage language="sage" component="html">
 <input>
 <xi:include href="./code/ev1-remark-span.sage" parse="text" />
 </input>

--- a/source/linear-algebra/source/02-EV/02.ptx
+++ b/source/linear-algebra/source/02-EV/02.ptx
@@ -205,7 +205,7 @@ since <m>\IR^1=\setBuilder{cx}{c\in\IR}</m>.
                 <m>\vspan\left\{\left[\begin{array}{c}1\\-1\\0\end{array}\right],
                 \left[\begin{array}{c}-2\\0\\1\end{array}\right],\left[\begin{array}{c}-2\\-2\\2\end{array}\right]\right\}</m>. 
             </p>
-            <sage language="octave">
+            <sage language="octave" component="html">
             </sage>
         </statement>
         <answer>
@@ -237,7 +237,7 @@ vector can't fail to belong.
                 <m>\vspan\left\{\left[\begin{array}{c}1\\-1\\0\end{array}\right],
                 \left[\begin{array}{c}-2\\0\\1\end{array}\right],\left[\begin{array}{c}-2\\-2\\2\end{array}\right]\right\}</m>. 
             </p>
-            <sage language="octave">
+            <sage language="octave" component="html">
             </sage>
         </statement>
         <answer>
@@ -253,7 +253,7 @@ The vector belongs to the span.
                 <m>\vspan\left\{\left[\begin{array}{c}1\\-1\\0\end{array}\right],
                 \left[\begin{array}{c}-2\\0\\1\end{array}\right],\left[\begin{array}{c}-2\\-2\\2\end{array}\right]\right\}</m>. 
             </p>
-            <sage language="octave">
+            <sage language="octave" component="html">
             </sage>
         </statement>
         <answer>
@@ -262,7 +262,7 @@ The vector does not belong to the span.
             </p>
         </answer>
     </task>
-    <task>
+    <task component="html">
         <statement>
             <p>
 Fix the SageMath code below to visualize
@@ -392,71 +392,9 @@ D.
         </p>
   </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
-
-<!-- <activity estimated-time='10'>
-    <introduction>
-        <p>
-  Consider the set of third-degree polynomials 
-            <md>
-                <mrow>
-  S=\{
-  &amp;2x^3+3x^2-1,
-  2x^3+3,
-  3x^3+13x^2+7x+16,
-                </mrow>
-                <mrow>
-  &amp;-x^3+10x^2+7x+14,
-  4x^3+3x^2+2 \} .
-                </mrow>
-            </md>
-            and the question
-            <q>
-  Does
-  <m>\P_3=\vspan S</m>?
-            </q>
-        </p>
-    </introduction>
-  <task><p>Rewrite this question to be about the solutions to a polynomial equation.
-      </p>
-  </task>
-  <task>
-      <p>
-      Answer your new question, and use this to answer the original question.
-      </p>
-  </task>
-</activity>
-<sage language="octave">
-</sage>
-
-
-<activity estimated-time='5'>
-    <introduction>
-    <p>
-Consider the set of matrices
-<me> S = \left\{
-    \left[\begin{array}{cc} 1 &amp; 3 \\ 0 &amp; 1 \end{array}\right],
-    \left[\begin{array}{cc} 1 &amp; -1 \\ 1 &amp; 0 \end{array}\right],
-    \left[\begin{array}{cc} 1 &amp; 0 \\ 0 &amp; 2 \end{array}\right]
-    \right\} </me>
-and the question <q>Does <m>M_{2,2} = \vspan S</m>?</q>
-    </p>
-    </introduction>
-  <task>
-      <p>
-      Rewrite this as a question about the solutions to a matrix equation.
-      </p>
-  </task>
-  <task>
-      <p>
-      Answer your new question, and use this to answer the original question.
-      </p>
-  </task>
-</activity>
-<sage language="octave">
-</sage> -->
 
 
 <activity estimated-time='5'>

--- a/source/linear-algebra/source/02-EV/04.ptx
+++ b/source/linear-algebra/source/02-EV/04.ptx
@@ -319,7 +319,7 @@ which isn't what was asked about.
             </task>
     </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <fact>
@@ -369,7 +369,7 @@ which isn't what was asked about.
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 
@@ -431,7 +431,7 @@ which isn't what was asked about.
       </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation xml:id="def_of_LI">
@@ -474,28 +474,6 @@ which isn't what was asked about.
         </p>
 </observation>
 
-<!-- <activity estimated-time='10'>
-    <introduction>
-        <p>
-  Consider whether the set of polynomials <m>\left\{
-  x^3+1,x^2+2x,x^2+7x+4
-  \right\}</m> is linearly dependent or linearly independent.
-        </p>
-    </introduction>
-<task>
-    <p>
-Reinterpret this question as an appropriate question about solutions to a polynomial equation.
-    </p>
-</task>
-<task>
-    <p>
-Use the solution to this question to answer the original question.
-    </p>
-</task>
-</activity>
-
-<sage language="octave">
-</sage> -->
 
 <activity estimated-time='5'>
     <statement>

--- a/source/linear-algebra/source/02-EV/05.ptx
+++ b/source/linear-algebra/source/02-EV/05.ptx
@@ -520,7 +520,7 @@ Not a basis, because not only does it fail to span <m>\IR^4</m>, it's also linea
 </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <activity estimated-time='10'>

--- a/source/linear-algebra/source/02-EV/06.ptx
+++ b/source/linear-algebra/source/02-EV/06.ptx
@@ -204,7 +204,7 @@ T=\left\{
   </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation>

--- a/source/linear-algebra/source/02-EV/07.ptx
+++ b/source/linear-algebra/source/02-EV/07.ptx
@@ -196,7 +196,7 @@ is already linearly independent and therefore already a basis for the subspace.
 
 
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 <activity estimated-time='10'>
     <introduction>
@@ -238,7 +238,7 @@ Find a basis for this solution space.
 </activity>
 
 
-<sage language="octave">
+<sage language="octave" component="html">
     <input>
     </input>
 </sage>
@@ -327,7 +327,7 @@ vector cannot be independent.
     </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 
@@ -373,7 +373,7 @@ shape of the data that gets projected onto this single point of the screen?
         </answer>
     </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 

--- a/source/linear-algebra/source/03-AT/02.ptx
+++ b/source/linear-algebra/source/03-AT/02.ptx
@@ -501,7 +501,7 @@ to the variable <c>v</c>, then compute <c>A*v</c>.
         </p>
     </statement>
     <answer>
-<sage language="octave">
+<sage language="octave" component="html">
     <input>
 format rat
 A = [
@@ -553,7 +553,7 @@ T\left(\left[\begin{array}{c} -2 \\ 5 \end{array}\right]\right)
     </answer>
 </task>
 </activity>
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 
 
 <activity>
@@ -574,7 +574,7 @@ T\left(\left[\begin{array}{c} -2 \\ 5 \end{array}\right]\right)
       <p>Compute <m>T\left(\left[\begin{array}{c} -5 \\ 0 \\ -3 \\ -2 \end{array}\right]\right)</m> using technology.</p>
     </statement>
     <answer>
-<sage language="octave">
+<sage language="octave" component="html">
     <input>
 format rat
 A = [

--- a/source/linear-algebra/source/03-AT/03.ptx
+++ b/source/linear-algebra/source/03-AT/03.ptx
@@ -209,7 +209,7 @@ Let <m>T: \IR^3 \rightarrow \IR^2</m> be the linear transformation with the foll
       </statement>
     </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation xml:id="observation-kernel-homogeneous-solution">
@@ -247,7 +247,7 @@ Find a basis for the kernel of <m>T</m>.
         </p>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 
@@ -503,7 +503,7 @@ In general, an arbitrary vector <m>\left[\begin{array}{c}\unknown\\\unknown\\\un
       </statement>
   </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation>
@@ -589,7 +589,7 @@ Find a basis for the kernel and a basis for the image of <m>T</m>.
         </p>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <activity estimated-time='5'>
@@ -696,7 +696,7 @@ The dimension of the image is called the <term>rank</term> of <m>T</m> (or <m>A<
     </answer> -->
   </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 </subsection>
@@ -770,7 +770,7 @@ Given a matrix <m>M</m>
         </p>
       </li>
     </ol>
-    <sage language="octave">
+    <sage language="octave" component="html">
 <input></input>
 </sage>
     </task>
@@ -791,7 +791,7 @@ Given a matrix <m>M</m>
         </p>
       </li>
     </ol>
-    <sage language="octave">
+    <sage language="octave" component="html">
 <input></input>
 </sage>
     </task>
@@ -813,7 +813,7 @@ Are the row space and column space of <m>N</m> both equal to <m>\mathbb{R}^3</m>
         </p>
       </li>
     </ol>
-    <sage language="octave">
+    <sage language="octave" component="html">
 <input></input>
 </sage>
     </task>

--- a/source/linear-algebra/source/03-AT/04.ptx
+++ b/source/linear-algebra/source/03-AT/04.ptx
@@ -897,7 +897,7 @@ Which of the following must be true?
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 <input>rref([2,1,-1; 4,1,1; 6,2,1])</input>
 </sage>
 
@@ -921,7 +921,7 @@ Which of the following must be true?
 </ol>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 <input>rref([2,1,-1; 4,1,1; 6,2,0])</input>
 </sage>
 
@@ -945,7 +945,7 @@ Which of the following must be true?
 </ol>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 <input>rref([2,3;1,-1;1,3])</input>
 </sage>
 
@@ -969,7 +969,7 @@ Which of the following must be true?
 </ol>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 <input>rref([2,1,-1;4,1,1])</input>
 </sage>
 

--- a/source/linear-algebra/source/04-MX/01.ptx
+++ b/source/linear-algebra/source/04-MX/01.ptx
@@ -261,7 +261,7 @@ B*A
     </cd>
 </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 <input>
 B = [3 -4 0 ; 2 0 -1 ; 0 -3 3]
 A = [2 7 -1 ; 0 3 2  ; 1 1 -1]

--- a/source/linear-algebra/source/04-MX/02.ptx
+++ b/source/linear-algebra/source/04-MX/02.ptx
@@ -38,7 +38,7 @@
         </p>
         </statement>
     </activity>
-    <sage language="octave">
+    <sage language="octave" component="html">
     </sage>
     
     <definition>
@@ -191,7 +191,7 @@ T^{-1}(\vec e_2)\hspace{1em}T^{-1}(\vec e_3)]
   </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 
@@ -251,7 +251,7 @@ Let <m>T\colon\IR^4\to\IR^4</m> be the linear bijection given by the standard ma
     </task>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation>
@@ -278,7 +278,7 @@ Is the matrix <m>\left[\begin{array}{ccc} 2 &amp; 3 &amp; 1 \\ -1 &amp; -4 &amp;
         </p>
     </statement>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <observation>
@@ -316,7 +316,7 @@ Is the matrix <m>\left[\begin{array}{ccc} 2 &amp; 3 &amp; 1 \\ -1 &amp; -4 &amp;
             </statement>
           </task>
     </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <activity estimated-time='10'>

--- a/source/linear-algebra/source/04-MX/03.ptx
+++ b/source/linear-algebra/source/04-MX/03.ptx
@@ -33,7 +33,7 @@
                 </p>
             </statement>
         </task>
-        <sage language="octave">
+        <sage language="octave" component="html">
             <input>
                 
             </input>
@@ -204,7 +204,7 @@
         <p>
             Calculate <m>M_{\mathcal{B}}=B^{-1}</m> using technology. 
         </p>
-        <sage language="octave">
+        <sage language="octave" component="html">
             <input>
                 
             </input>
@@ -313,7 +313,7 @@ but where inputs and outputs are all given in <m>\mathcal B</m>-coordinates?
         <p>
             Calculate the matrix <m>M_\mathcal{B}AM_{\mathcal{B}}^{-1}</m>.
         </p>
-        <sage language="octave">
+        <sage language="octave" component="html">
             <input>
                 
             </input>

--- a/source/linear-algebra/source/04-MX/04.ptx
+++ b/source/linear-algebra/source/04-MX/04.ptx
@@ -184,7 +184,7 @@ the first row when left-multiplying? (<m>R_1+5R_3\to R_1</m>)
     </p>
 </task>
 </activity>
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <fact xml:id="row-reduction-decomposition">
@@ -313,7 +313,7 @@ Check your work using technology.
     </statement>
 </activity>
 
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 
 <activity>
     <task>
@@ -364,7 +364,7 @@ Check your work using technology.
     </task>
   </activity>
 
-<sage language="octave"/>
+<sage language="octave" component="html"/>
 </subsection>
 
 <subsection>

--- a/source/linear-algebra/source/04-MX/samples/01.ptx
+++ b/source/linear-algebra/source/04-MX/samples/01.ptx
@@ -29,7 +29,7 @@ Of the following three matrices, only two may be multiplied.
             <p>Find their product using technology.</p>
         </statement>
         <solution>
-            <sage language="octave">
+            <sage language="octave" component="html">
                 <input>
 A = [
 -1 3 -2 -3

--- a/source/linear-algebra/source/04-MX/samples/04.ptx
+++ b/source/linear-algebra/source/04-MX/samples/04.ptx
@@ -53,7 +53,7 @@
             <me>\sim\left[\begin{array}{ccc} -5 &amp; 15 &amp; 15 \\ 2 &amp; -6 &amp; -5 \\ -4 &amp; 12 &amp; 12 \end{array}\right]
             \sim\left[\begin{array}{ccc} -4 &amp; 12 &amp; 12 \\ 2 &amp; -6 &amp; -5 \\ -5 &amp; 15 &amp; 15 \end{array}\right]</me>
         </p>  
-            <sage language="octave">
+            <sage language="octave" component="html">
                 <input>
 C = [
     -5 0 0

--- a/source/linear-algebra/source/05-GT/02.ptx
+++ b/source/linear-algebra/source/05-GT/02.ptx
@@ -411,7 +411,7 @@ Based on the previous activities, which technique is easier for computing determ
     </statement>
 </activity>
 
-<insight>You can check your answers using technology.
+<insight component="html"><p>You can check your answers using technology.</p>
 <sage language="octave">
 <input>det([4,-3,0,0; 1,-3,2,-1; 3,2,0,3; 0,-3,2,-2])</input>
 </sage>

--- a/source/linear-algebra/source/05-GT/04.ptx
+++ b/source/linear-algebra/source/05-GT/04.ptx
@@ -52,7 +52,7 @@ to find all the eigenvectors <m>\vec x</m> such that <m>A\vec x=-2\vec x</m>.
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <definition>
@@ -80,7 +80,7 @@ associated with the eigenvalue <m>3</m>.
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 <activity estimated-time='10'>
@@ -97,7 +97,7 @@ associated with the eigenvalue <m>1</m>.
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 
 
@@ -116,7 +116,7 @@ associated with the eigenvalue <m>2</m>.
     </statement>
 </activity>
 
-<sage language="octave">
+<sage language="octave" component="html">
 </sage>
 </subsection>
 


### PR DESCRIPTION
The sagecells, particularly the empty ones, provide little value to the printed version. This sets them all to the HTML component.  There were a couple new activities that asked students to edit sage code, alternate versions of these tasks were added for the print version.

Closes #960 