### PR TITLE
Convert readiness assurance to use assemblage

### DIFF
--- a/source/calculus/source/01-LT/readiness.ptx
+++ b/source/calculus/source/01-LT/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="LT-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="LT-readiness">
+</assemblage xml:id="LT-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -102,5 +102,5 @@
 </li>   
         
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/02-DF/readiness.ptx
+++ b/source/calculus/source/02-DF/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="DF-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <paragraphs xml:id="DF-readiness">
+</assemblage xml:id="DF-readiness">
     <title>Readiness Assurance</title>
       <p>
         Before beginning this chapter, you should be able to...
@@ -26,5 +26,5 @@
             <p>Recall special trig values on the unit circle (<url href="https://www.khanacademy.org/math/get-ready-for-ap-calc/xa350bf684c056c5c:get-ready-for-limits-and-continuity/xa350bf684c056c5c:special-trig-values-in-q1/v/solving-triangle-unit-circle">Khan Academy (1) </url> and <url href="https://www.khanacademy.org/math/get-ready-for-ap-calc/xa350bf684c056c5c:get-ready-for-limits-and-continuity/xa350bf684c056c5c:unit-circle-introduction/v/unit-circle-definition-of-trig-functions-1">Khan Academy (2) </url>)</p>
         </li>           
       </ol>
-  </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/03-AD/readiness.ptx
+++ b/source/calculus/source/03-AD/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="AD-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <paragraphs xml:id="AD-readiness">
+</assemblage xml:id="AD-readiness">
     <title>Readiness Assurance</title>
       <p>
         Before beginning this chapter, you should be able to...
@@ -29,5 +29,5 @@
         </li>         
          
       </ol>
-  </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/04-IN/readiness.ptx
+++ b/source/calculus/source/04-IN/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="IN-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <paragraphs xml:id="IN-readiness">
+</assemblage xml:id="IN-readiness">
     <title>Readiness Assurance</title>
       <p>
         Before beginning this chapter, you should be able to...
@@ -17,5 +17,5 @@
         <li><p>Find the intersection of two graphs. (<url href="https://www.khanacademy.org/math/algebra2/x2ec2f6f830c9fb89:eq/x2ec2f6f830c9fb89:quad-sys/v/line-and-parabola-system">Khan Academy</url>)</p></li>
          <li><p>Find the area of plane shapes, such as rectangles, triangles, circles, and trapezoids. (<url href="https://www.mathsisfun.com/area.html">Math is fun</url>)</p></li>
       </ol>
-  </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/05-TI/readiness.ptx
+++ b/source/calculus/source/05-TI/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="TI-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="TI-readiness">
+</assemblage xml:id="TI-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -67,5 +67,5 @@
             </ul>
         </li>
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/06-AI/readiness.ptx
+++ b/source/calculus/source/06-AI/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="AI-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="AI-readiness">
+</assemblage xml:id="AI-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -53,5 +53,5 @@
         </li>
         
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/07-CO/readiness.ptx
+++ b/source/calculus/source/07-CO/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="CO-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="CO-readiness">
+</assemblage xml:id="CO-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -23,5 +23,5 @@
             <p>Find an integral which computes the arclength of a curve using methods from <xref ref="DF4" />.</p>
         </li>
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/08-SQ/readiness.ptx
+++ b/source/calculus/source/08-SQ/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="SQ-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="SQ-readiness">
+</assemblage xml:id="SQ-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -36,5 +36,5 @@
         </li>
         
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/calculus/source/09-PS/readiness.ptx
+++ b/source/calculus/source/09-PS/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="PS-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="PS-readiness">
+</assemblage xml:id="PS-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -52,5 +52,5 @@
         
         
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/linear-algebra/source/04-MX/readiness.ptx
+++ b/source/linear-algebra/source/04-MX/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="MX-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="MX-readiness">
+    <assemblage xml:id="MX-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -48,5 +48,5 @@
             </ul>
         </li>
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/linear-algebra/source/05-GT/readiness.ptx
+++ b/source/linear-algebra/source/05-GT/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="GT-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="GT-readiness">
+    <assemblage xml:id="GT-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -50,5 +50,5 @@
             </ul>
         </li>
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/linear-algebra/source/future-ON/readiness.ptx
+++ b/source/linear-algebra/source/future-ON/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="ON-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="ON-readiness">
+    <assemblage xml:id="ON-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -24,5 +24,5 @@
             </ul>
         </li>
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/01-EQ/readiness.ptx
+++ b/source/precalculus/source/01-EQ/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="EQ-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="EQ-readiness">
+    <assemblage xml:id="EQ-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -94,5 +94,5 @@
 
 
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/02-FN/readiness.ptx
+++ b/source/precalculus/source/02-FN/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="FN-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="FN-readiness">
+    <assemblage xml:id="FN-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -70,6 +70,6 @@
        
  
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>
 

--- a/source/precalculus/source/03-LF/readiness.ptx
+++ b/source/precalculus/source/03-LF/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="LF-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="LF-readiness">
+    <assemblage xml:id="LF-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...

--- a/source/precalculus/source/04-PR/readiness.ptx
+++ b/source/precalculus/source/04-PR/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="PR-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="PR-readiness">
+    <assemblage xml:id="PR-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -117,5 +117,5 @@
 
 
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/05-EL/readiness.ptx
+++ b/source/precalculus/source/05-EL/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="EL-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="EL-readiness">
+</assemblage xml:id="EL-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -53,5 +53,5 @@
         </li>
  
     </ol>
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/06-TR/readiness.ptx
+++ b/source/precalculus/source/06-TR/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="TR-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="TR-readiness">
+</assemblage xml:id="TR-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -50,5 +50,5 @@
 
     </ol>
     
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/07-PF/readiness.ptx
+++ b/source/precalculus/source/07-PF/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="PF-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="PF-readiness">
+</assemblage xml:id="PF-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -44,5 +44,5 @@
 
     </ol>
     
-    </paragraphs>
+</assemblage>
 </introduction>

--- a/source/precalculus/source/08-TE/readiness.ptx
+++ b/source/precalculus/source/08-TE/readiness.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 
 <introduction xml:id="TE-intro" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <paragraphs xml:id="TE-readiness">
+</assemblage xml:id="TE-readiness">
     <title>Readiness Assurance</title>
     <p>
         Before beginning this chapter, you should be able to...
@@ -49,5 +49,5 @@
 
     </ol>
     
-    </paragraphs>
+</assemblage>
 </introduction>


### PR DESCRIPTION
The first few modules of the linear algebra book use `<assemblage>` to contain the readiness assurance (e.g. [Assemblage: Readiness Assurance](https://tbil.org/preview/linear-algebra/LE.html#LE-readiness) ) while the latter modules, and the other books, use `<paragraphs>` (e.g. [Paragraphs: Readiness Assurance](https://tbil.org/preview/linear-algebra/GT.html#GT-readiness) ).  I prefer the typesetting in a box from `<assemblage>`, particularly for the PDF version, so this homogenizes all of our books to use `<assemblage>`