### PR TITLE
XSL to put definitions in boxes

### DIFF
--- a/xsl/print.xsl
+++ b/xsl/print.xsl
@@ -42,5 +42,11 @@
     </xsl:for-each>
   </xsl:template>
 
+  <!--Put definitions in boxes-->
+  <xsl:template match="definition" mode="tcb-style">
+    <xsl:text>colframe=black!30!white,</xsl:text>
+    <xsl:text>coltitle=black,</xsl:text>
+    <xsl:text>fonttitle=\bfseries,</xsl:text>
+  </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Addresses #953.  This typesets definitions in boxes with a gray background in the print version.

<img width="425" height="220" alt="image" src="https://github.com/user-attachments/assets/d0f3ca9b-7348-4426-8b73-e9f8b4188718" />
