### PR TITLE
Make page references parenthetical

### DIFF
--- a/xsl/print.xsl
+++ b/xsl/print.xsl
@@ -49,4 +49,28 @@
     <xsl:text>fonttitle=\bfseries,</xsl:text>
   </xsl:template>
 
+  <!--Tweak display of references-->
+  <xsl:template match="xref" mode="latex-page-number">
+      <xsl:param name="target"/>
+
+      <xsl:choose>
+          <!-- looks bad when bibliographic number gets wrapped in [] -->
+          <!-- and the number should suffice on its own               -->
+          <xsl:when test="$target/self::biblio"/>
+          <!-- and trailing a () for an equation number is overkill -->
+          <xsl:when test="$target/self::mrow|$target/self::md"/>
+          <!-- and it is really bad for an xref inside a title -->
+          <xsl:when test="ancestor::title"/>
+          <!-- off by default electronic PDF, -->
+          <!-- or on by default for print PDF -->
+          <xsl:when test="not($b-pageref)"/>
+          <!-- OK, requested and helps, let's add it -->
+          <xsl:otherwise>
+              <xsl:text> (p.\,\pageref{</xsl:text>
+              <xsl:apply-templates select="$target" mode="unique-id"/>
+              <xsl:text>})</xsl:text>
+          </xsl:otherwise>
+      </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
The default way of displaying references in PDF is

<img width="428" height="42" alt="image" src="https://github.com/user-attachments/assets/9cdc0ac0-0552-4676-a8bc-88b2fc37d3b9" />

This changes the behavior to have a parenthetical instead

<img width="437" height="45" alt="image" src="https://github.com/user-attachments/assets/4da0faf0-ac1b-42f1-9a19-99037bc28e63" />

HTML output is unaffected since it does not use this xsl file.