### PR TITLE
Remove duplicate word

### DIFF
--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -941,7 +941,7 @@ rref(A)
         <exploration>
         <statement>
             <p>
-            Let <m>M_{2,2}</m> indicate the set of all <m>2 \times 2</m> matrices with real entries. Show that equivalence of matrices as defined in this section is an equivalence relation, as in exploration <xref ref="equiv_relation"></xref></p>
+            Let <m>M_{2,2}</m> indicate the set of all <m>2 \times 2</m> matrices with real entries. Show that equivalence of matrices as defined in this section is an equivalence relation, as in <xref ref="equiv_relation"></xref></p>
             </statement></exploration>
     </subsection>
     


### PR DESCRIPTION
xrefs include words like "exploration" so it is not needed in the text.