### PR TITLE
Make readiness resources html only

### DIFF
--- a/source/linear-algebra/source/01-LE/readiness.ptx
+++ b/source/linear-algebra/source/01-LE/readiness.ptx
@@ -9,7 +9,7 @@
         <li>
             <p>Determine if a system to a two-variable system of linear equations
                 will have zero, one, or infinitely-many solutions by graphing.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="http://bit.ly/2l21etm">Khan Academy</url></p>
                 </li>
@@ -19,7 +19,7 @@
             <p>
                 Find the unique solution to a two-variable system of linear equations
                 by back-substitution.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.khanacademy.org/math/algebra-basics/alg-basics-systems-of-equations/alg-basics-solving-systems-with-substitution/v/practice-using-substitution-for-systems">Khan Academy</url></p>
                 </li>
@@ -27,7 +27,7 @@
         </li>
         <li>
             <p>Describe sets using set-builder notation, and check if an element is a member of a set described by set-builder notation.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://youtu.be/xnfUZ-NTsCE">YouTube</url></p>
                 </li>

--- a/source/linear-algebra/source/02-EV/readiness.ptx
+++ b/source/linear-algebra/source/02-EV/readiness.ptx
@@ -8,7 +8,7 @@
     <ol marker="1.">
         <li>
             <p>Use set builder notation to describe sets of vectors.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://youtu.be/xnfUZ-NTsCE">YouTube</url></p>
                 </li>
@@ -16,7 +16,7 @@
         </li>
         <li>
             <p>Add Euclidean vectors and multiply Euclidean vectors by scalars.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.khanacademy.org/math/linear-algebra/vectors-and-spaces/vectors/v/adding-vectors">Khan Academy (1)</url>
                     <url href="https://www.khanacademy.org/math/linear-algebra/vectors-and-spaces/vectors/v/multiplying-vector-by-scalar">(2)</url></p>
@@ -26,7 +26,7 @@
         <li>
             <p>Perform basic manipulations of augmented matrices and linear
                 systems.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>
                         Review:

--- a/source/linear-algebra/source/03-AT/readiness.ptx
+++ b/source/linear-algebra/source/03-AT/readiness.ptx
@@ -8,7 +8,7 @@
     <ol marker="1.">
         <li>
             <p>State the definition of a spanning set, and determine if a set of Euclidean vectors spans <m>\IR^n</m>.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="EV2"/></p>
                 </li>
@@ -16,7 +16,7 @@
         </li>
         <li>
             <p>State the definition of linear independence, and determine if a set of Euclidean vectors is linearly dependent or independent.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="EV4"/></p>
                 </li>
@@ -25,7 +25,7 @@
         <li>
             <p>
             State the definition of a basis, and determine if a set of Euclidean vectors is a basis.
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="EV5"/>,
                     <xref ref="EV6"/></p>

--- a/source/linear-algebra/source/04-MX/readiness.ptx
+++ b/source/linear-algebra/source/04-MX/readiness.ptx
@@ -8,7 +8,7 @@
     <ol marker="1.">
         <li>
             <p>Compose functions of real numbers.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.khanacademy.org/math/precalculus/composite/composing/v/function-composition">Khan Academy</url></p>
                 </li>
@@ -16,7 +16,7 @@
         </li>
         <li>
             <p>Identify the domain and codomain of linear transformations.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.youtube.com/watch?v=BQMyeQOLvpg">YouTube</url></p>
                 </li>
@@ -24,7 +24,7 @@
         </li>
         <li>
             <p>Find the matrix corresponding to a linear transformation and compute the image of a vector given a standard matrix.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="AT2"/></p>
                 </li>
@@ -32,7 +32,7 @@
         </li>
         <li>
             <p>Determine if a linear transformation is injective and/or surjective.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="AT4"/></p>
                 </li>
@@ -40,7 +40,7 @@
         </li>
         <li>
             <p>Interpret the ideas of injectivity and surjectivity in multiple ways.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.youtube.com/watch?v=WpUv72Y6Dl0">YouTube</url></p>
                 </li>

--- a/source/linear-algebra/source/05-GT/readiness.ptx
+++ b/source/linear-algebra/source/05-GT/readiness.ptx
@@ -8,7 +8,7 @@
     <ol marker="1.">
         <li>
             <p>Calculate the area of a parallelogram.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.khanacademy.org/math/cc-sixth-grade-math/cc-6th-geometry-topic/cc-6th-parallelogram-area/v/intuition-for-area-of-a-parallelogram">Khan Academy</url></p>
                 </li>
@@ -16,7 +16,7 @@
         </li>
         <li>
             <p>Recall and use the definition of a linear transformation.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="AT1"/></p>
                 </li>
@@ -24,7 +24,7 @@
         </li>
         <li>
             <p>Find the matrix corresponding to a linear transformation of Euclidean spaces.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="AT2"/></p>
                 </li>
@@ -32,7 +32,7 @@
         </li>
         <li>
             <p>Find all roots of quadratic polynomials (including complex ones).</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <url href="https://www.khanacademy.org/math/algebra-home/alg-polynomials/alg-factoring-polynomials-quadratic-forms/v/factoring-trinomials-by-grouping-5">Khan Academy</url>,
                     <url href="https://youtu.be/Aa-v1EK7DR4">YouTube (1)</url>,
@@ -42,7 +42,7 @@
         </li>
         <li>
             <p>Interpret the statement <q><m>A</m> is an invertible matrix</q> in many equivalent ways in different contexts.</p>
-            <ul>
+            <ul component="html">
                 <li>
                     <p>Review: <xref ref="MX3"/></p>
                 </li>


### PR DESCRIPTION
Since the readiness resources are often long ugly links, I have removed them from the print version.  Together with #986 this closes #961