### PR TITLE
Make interactives print-ready

### DIFF
--- a/source/linear-algebra/source/01-LE/01.ptx
+++ b/source/linear-algebra/source/01-LE/01.ptx
@@ -246,6 +246,12 @@ Following are some examples of addition and scalar multiplication in <m>\mathbb 
           </description>
         </interactive>
     </figure>
+    <paragraphs component="print">
+        <title>Note</title>
+        <p>This book occasionally contains interactive tools for visualizing vectors.  They
+            are each accompanied by a QR code you can scan to access the interactive.
+        </p>
+    </paragraphs>
     <figure xml:id="figure-le1-scalar-mult">
         <caption>Visualization of adding vectors</caption>
         <interactive label="LE1-interactive-scalar-mult" platform="doenetml" width="100%">

--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -334,6 +334,7 @@ Replace a row with zeros, for example:
 
 <activity xml:id="LE2-activity-add-rows">
     <statement>
+      <p>Use the interactive below to answer this question.</p>
         <interactive label="AT1-interactive-add-rows" platform="doenetml" width="100%">
           <slate surface="doenetml">
             <xi:include parse="text" href="doenet/LE2-add-rows.xml"/>

--- a/source/linear-algebra/source/05-GT/01.ptx
+++ b/source/linear-algebra/source/05-GT/01.ptx
@@ -338,6 +338,7 @@ area of resulting parallelogram, what is the value of <m>\det([\vec{e}_1\hspace{
 
 <activity estimated-time='2'>
     <statement>
+      <p component="print">Use the interactive below to answer this question.</p>
       <interactive label="GT1-interactive-duplicate-column" platform="doenetml" width="90%" aspect="3:4">
         <slate surface="doenetml">
           <xi:include parse="text" href="doenet/GT1-doenet-duplicate-column.xml"/>
@@ -359,6 +360,7 @@ area of resulting parallelogram, what is the value of <m>\det([\vec{e}_1\hspace{
 
 <activity estimated-time='5' xml:id="GT1-activity-scale-column">
   <statement>
+      <p component="print">Use the interactive below to answer this question.</p>
     <interactive label="GT1-interactive-scale-column" platform="doenetml" width="100%" aspect="3:2">
       <slate surface="doenetml">
         <xi:include parse="text" href="doenet/GT1-doenet-scale-column.xml"/>
@@ -387,6 +389,7 @@ parallelogram.
 
 <activity estimated-time='5' xml:id="GT1-activity-add-column">
   <statement>
+      <p component="print">Use the interactive below to answer this question.</p>
     <interactive label="GT1-interactive-add-column" platform="doenetml" width="100%" aspect="3:2">
       <slate surface="doenetml">
         <xi:include parse="text" href="doenet/GT1-doenet-add-column.xml"/>

--- a/source/linear-algebra/source/05-GT/03.ptx
+++ b/source/linear-algebra/source/05-GT/03.ptx
@@ -181,6 +181,7 @@ and we call this <m>\lambda</m> an <term>eigenvalue</term><idx>eigenvalue</idx> 
 
 <activity>
   <statement>
+      <p component="print">Use the interactive below to answer this question.</p>
     <interactive label="GT3-interactive-eigenvector" platform="doenetml" width="95%" aspect="3:5">
       <slate surface="doenetml">
         <xi:include parse="text" href="doenet/GT3-doenet-eigenvector.xml"/>

--- a/xsl/print.xsl
+++ b/xsl/print.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:pi="http://pretextbook.org/2020/pretext/internal">
   <xsl:import href="./core/pretext-latex.xsl" />
 
 
@@ -72,5 +72,95 @@
           </xsl:otherwise>
       </xsl:choose>
   </xsl:template>
+
+  <!--Controls display of videos and interactives-->
+  <xsl:template match="video|interactive[not(static)]" mode="representations">
+    <xsl:choose>
+        <xsl:when test="$exercise-style = 'static'">
+            <!-- panel widths are experimental -->
+            <sidebyside margins="7.5% 7.5%" widths="45% 25%" valign="middle" halign="center">
+                <!-- copy over @xml:id, which may be in use by -->
+                <!-- page-breaking mechanism for LaTeX output  -->
+                <xsl:copy-of select="@xml:id"/>
+                <!-- A @label could mask an authored @xml:id           -->
+                <!-- Note: this may be manufactured by an earlier pass -->
+                <xsl:copy-of select="@label"/>
+                <xsl:choose>
+                    <!-- @preview present, so author provides a static image  -->
+                    <!--                                                      -->
+                    <!-- "video" is exceptional, we allow for a generic image -->
+                    <xsl:when test="self::video and (@preview = 'generic')">
+                        <image>
+                            <xsl:attribute name="pi:generated">
+                                <xsl:text>play-button/play-button.png</xsl:text>
+                            </xsl:attribute>
+                        </image>
+                    </xsl:when>
+                    <!--  -->
+                    <xsl:when test="@preview">
+                        <image>
+                            <xsl:attribute name="source">
+                                <xsl:value-of select="@preview"/>
+                            </xsl:attribute>
+                        </image>
+                    </xsl:when>
+                    <!-- semi-automatic images vary by format     -->
+                    <!--                                          -->
+                    <!-- interactive: screenshots with playwright -->
+                    <!-- video: we scrape YouTube, only           -->
+                    <!--        YouTube playlist gets generic     -->
+                    <!-- audio: immature                          -->
+                    <xsl:when test="self::interactive">
+                        <image>
+                            <xsl:attribute name="pi:generated">
+                                <xsl:text>preview/</xsl:text>
+                                <xsl:apply-templates select="." mode="assembly-id"/>
+                                <xsl:text>-preview.png</xsl:text>
+                            </xsl:attribute>
+                        </image>
+                    </xsl:when>
+                    <!--  -->
+                    <xsl:when test="self::video and @youtube">
+                        <image>
+                            <xsl:attribute name="pi:generated">
+                                <xsl:text>youtube/</xsl:text>
+                                <xsl:apply-templates select="." mode="assembly-id"/>
+                                <xsl:text>.jpg</xsl:text>
+                            </xsl:attribute>
+                        </image>
+                    </xsl:when>
+                    <!--  -->
+                    <xsl:when test="self::video and @youtubeplaylist">
+                        <image>
+                            <xsl:attribute name="pi:generated">
+                                <xsl:text>play-button/play-button.png</xsl:text>
+                            </xsl:attribute>
+                        </image>
+                    </xsl:when>
+                    <!--  -->
+                    <xsl:otherwise>
+                        <p>BUG: PREVIEW NOT HANDLED</p>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <stack>
+                    <!-- Remove bit of code including urls, keep only image of QR code-->
+                    <image>
+                        <xsl:attribute name="pi:generated">
+                            <xsl:text>qrcode/</xsl:text>
+                            <xsl:apply-templates select="." mode="assembly-id"/>
+                            <xsl:text>.png</xsl:text>
+                        </xsl:attribute>
+                    </image>
+                </stack>
+            </sidebyside>
+        </xsl:when>
+        <xsl:when test="($exercise-style = 'dynamic') or ($exercise-style = 'pg-problems')">
+            <!-- duplicate authored content for the non-static conversions -->
+            <xsl:copy>
+                <xsl:apply-templates select="node()|@*" mode="representations"/>
+            </xsl:copy>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Closes #958.  I customized the display of interactives and videos in the print version, and added some print-only text around the interactives.