### PR TITLE
Remove stray unused abbreviation

### DIFF
--- a/source/linear-algebra/source/01-LE/04.ptx
+++ b/source/linear-algebra/source/01-LE/04.ptx
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <section xml:id="LE4" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title component="print">Linear Systems with Infinitely Many Solutions (LE4)</title>
-    <title component="html">Linear Systems with Infinitely Many Solutions</title>
+    <title component="html">Linear Systems with Infinitely Many Solutions (LE4)</title>
+    <title component="print">Linear Systems with Infinitely Many Solutions</title>
     <objectives>
         <ul>
             <li>


### PR DESCRIPTION
I removed most abbreviations of chapters/sections from the print version already, but this one slipped through.