### PR TITLE
Alter presentation of sample exercises

### DIFF
--- a/source/linear-algebra/source/01-LE/samples/01.ptx
+++ b/source/linear-algebra/source/01-LE/samples/01.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-LE1">
-    <title>LE1</title>
+<exercise xml:id="sample-LE1">
+    <title component="html">LE1</title>
+    <title component="print"><xref ref="LE1" text="global"/></title>
     <introduction>
       <p> Consider the vector equation <me>x_{1} \left[\begin{array}{c} 4 \\ -3 \\ 3 \end{array}\right] + x_{2} \left[\begin{array}{c} 4 \\ -3 \\ 3 \end{array}\right] + x_{3} \left[\begin{array}{c} 3 \\ 1 \\ 3 \end{array}\right] + x_{4} \left[\begin{array}{c} 18 \\ -7 \\ 15 \end{array}\right] = \left[\begin{array}{c} -11 \\ 5 \\ -9 \end{array}\right]</me></p>
     </introduction>
@@ -34,4 +35,4 @@
           </p>
         </solution>
       </task>
-    </example>
+    </exercise>

--- a/source/linear-algebra/source/01-LE/samples/02.ptx
+++ b/source/linear-algebra/source/01-LE/samples/02.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-LE2"><title>LE2</title>
+<exercise xml:id="sample-LE2">
+  <title component="html">LE2</title>
+  <title component="print"><xref ref="LE2" text="global"/></title>
     <task>
         <introduction>
           <p> For each of the following matrices, explain why it is not in reduced row echelon form. </p>
@@ -107,4 +109,4 @@
           </p>
         </solution>
       </task>
-</example>
+    </exercise>

--- a/source/linear-algebra/source/01-LE/samples/03.ptx
+++ b/source/linear-algebra/source/01-LE/samples/03.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-LE3"><title>LE3</title>
+<exercise xml:id="sample-LE3">
+  <title component="html">LE3</title>
+  <title component="print"><xref ref="LE3" text="global"/></title>
   <introduction>
     <p> Consider each of the following systems of linear equations or vector equations. </p>
   </introduction>
@@ -130,4 +132,4 @@
         </solution>
       </task>
   </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/01-LE/samples/04.ptx
+++ b/source/linear-algebra/source/01-LE/samples/04.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-LE4"><title>LE4</title>
+<exercise xml:id="sample-LE4">
+  <title component="html">LE4</title>
+  <title component="print"><xref ref="LE4" text="global"/></title>
   <introduction>
     <p> Consider the following vector equation. <me>x_{1} \left[\begin{array}{c} 1 \\ 0 \\ 1 \\ 1 \end{array}\right] + x_{2} \left[\begin{array}{c} -2 \\ 0 \\ -2 \\ -2 \end{array}\right] + x_{3} \left[\begin{array}{c} -5 \\ 1 \\ -5 \\ -2 \end{array}\right] + x_{4} \left[\begin{array}{c} 13 \\ -2 \\ 13 \\ 7 \end{array}\right] + x_{5} \left[\begin{array}{c} -14 \\ 3 \\ -14 \\ -5 \end{array}\right] = \left[\begin{array}{c} 18 \\ -3 \\ 18 \\ 9 \end{array}\right]</me> </p>
   </introduction>
@@ -47,4 +49,4 @@
         <p>Therefore, the solution set is <m>\left\{ \left[\begin{array}{c} 2 \, a - 3 \, b - c + 3 \\ a \\ 2 \, b - 3 \, c - 3 \\ b \\ c \end{array}\right] \,\middle|\, a,b,c \in\mathbb R \right\}</m>.</p>
       </solution>
     </task>
-</example>    
+  </exercise>    

--- a/source/linear-algebra/source/02-EV/samples/01.ptx
+++ b/source/linear-algebra/source/02-EV/samples/01.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-EV1"><title>EV1</title>
+<exercise xml:id="sample-EV1">
+  <title component="html">EV1</title>
+  <title component="print"><xref ref="EV1" text="global"/></title>
     <introduction>
       <p>Consider each of these claims about a vector equation.</p>
     </introduction>
@@ -97,4 +99,4 @@ x_4\left[\begin{array}{c} -5 \\ 1 \\ -5 \end{array}\right]  =
             </solution>
           </task>
       </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/02-EV/samples/02.ptx
+++ b/source/linear-algebra/source/02-EV/samples/02.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-EV2"><title>EV2</title>
+<exercise xml:id="sample-EV2">
+    <title component="html">EV2</title>
+    <title component="print"><xref ref="EV2" text="global"/></title>
     <task>
         <introduction>
             <p> Consider the set of vectors <me>\left\{ \left[\begin{array}{c} -1 \\ 1 \\ 0 \\ 2 \end{array}\right] , 
@@ -137,4 +139,4 @@
             </solution>
         </task>
     </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/02-EV/samples/03.ptx
+++ b/source/linear-algebra/source/02-EV/samples/03.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-EV3"><title>EV3</title>
+<exercise xml:id="sample-EV3">
+  <title component="html">EV3</title>
+  <title component="print"><xref ref="EV3" text="global"/></title>
   <introduction>
     <p> Answer the following questions about Euclidean subspaces. </p>
   </introduction>
@@ -95,4 +97,4 @@
         </p>
       </solution>
     </task>
-</example>
+  </exercise>

--- a/source/linear-algebra/source/02-EV/samples/04.ptx
+++ b/source/linear-algebra/source/02-EV/samples/04.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-EV4"><title>EV4</title>
+<exercise xml:id="sample-EV4">
+  <title component="html">EV4</title>
+  <title component="print"><xref ref="EV4" text="global"/></title>
     <task>
       <introduction>
         <p>
@@ -116,4 +118,4 @@
           </solution>
         </task>
     </task>
-</example>
+  </exercise>

--- a/source/linear-algebra/source/02-EV/samples/05.ptx
+++ b/source/linear-algebra/source/02-EV/samples/05.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-EV5"><title>EV5</title>
+<exercise xml:id="sample-EV5">
+  <title component="html">EV5</title>
+  <title component="print"><xref ref="EV5" text="global"/></title>
       <task>
         <introduction>
           <p> Consider the set of vectors <me>\left\{ \left[\begin{array}{c} 1 \\ -2 \\ 0 \\ 1 \end{array}\right] , \left[\begin{array}{c} 2 \\ -4 \\ 0 \\ 2 \end{array}\right] , \left[\begin{array}{c} 3 \\ -6 \\ 0 \\ 3 \end{array}\right] , \left[\begin{array}{c} 5 \\ -5 \\ -2 \\ 4 \end{array}\right] \right\}</me> </p>
@@ -79,4 +81,4 @@
             </solution>
           </task>
       </task>
-</example>
+    </exercise>

--- a/source/linear-algebra/source/02-EV/samples/06.ptx
+++ b/source/linear-algebra/source/02-EV/samples/06.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-EV6"><title>EV6</title>
+<exercise xml:id="sample-EV6">
+    <title component="html">EV6</title>
+    <title component="print"><xref ref="EV6" text="global"/></title>
 <introduction>
     <p>
 Consider the subspace 
@@ -63,4 +65,4 @@ Since this (and thus every other) basis has three vectors in it, the dimension o
             </p>
         </solution>
     </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/02-EV/samples/07.ptx
+++ b/source/linear-algebra/source/02-EV/samples/07.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-EV7"><title>EV7</title>
+<exercise xml:id="sample-EV7">
+    <title component="html">EV7</title>
+    <title component="print"><xref ref="EV7" text="global"/></title>
 <introduction>
     <p>
 Consider the homogeneous system of equations
@@ -86,4 +88,4 @@ a basis for the solution space is
             </p>
     </solution>
 </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/01.ptx
+++ b/source/linear-algebra/source/03-AT/samples/01.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-AT1"><title>AT1</title>
+<exercise xml:id="sample-AT1">
+    <title component="html">AT1</title>
+    <title component="print"><xref ref="AT1" text="global"/></title>
 <statement>
     <p> Answer the following questions about transformations.
     <ol>
@@ -124,4 +126,4 @@
         </li>
     </ol></p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/02.ptx
+++ b/source/linear-algebra/source/03-AT/samples/02.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-AT2"><title>AT2</title>
+<exercise xml:id="sample-AT2">
+    <title component="html">AT2</title>
+    <title component="print"><xref ref="AT2" text="global"/></title>
 <statement>
     <p>
     <ol>
@@ -52,4 +54,4 @@ S\left(\left[\begin{array}{c} -2 \\ 1 \\ 3 \\ 2 \end{array}\right] \right) = -2S
     </ol>
     </p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/03.ptx
+++ b/source/linear-algebra/source/03-AT/samples/03.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-AT3"><title>AT3</title>
+<exercise xml:id="sample-AT3">
+    <title component="html">AT3</title>
+    <title component="print"><xref ref="AT3" text="global"/></title>
 <statement>
     <p>
 Let <m>T: \IR^4 \rightarrow \IR^3</m> be the linear transformation given by
@@ -99,4 +101,4 @@ of the rank and nullity of <m>T</m> is the dimension of the domain of <m>T</m>.
     </ol>
     </p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/04.ptx
+++ b/source/linear-algebra/source/03-AT/samples/04.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-AT4"><title>AT4</title>
+<exercise xml:id="sample-AT4">
+    <title component="html">AT4</title>
+    <title component="print"><xref ref="AT4" text="global"/></title>
 <statement>
     <p>
 Let <m>T: \IR^4 \rightarrow \IR^3</m> be the linear transformation given by the standard matrix <m>\left[\begin{array}{cccc} 1 &amp; 3 &amp; 2 &amp; -3 \\ 2 &amp; 4 &amp; 6 &amp; -10 \\ 1 &amp; 6 &amp; -1 &amp; 3 \end{array}\right]</m>.
@@ -35,4 +37,4 @@ Since there are only two pivots, the image (i.e. the span of the columns) is a 2
     </ol>
     </p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/05.ptx
+++ b/source/linear-algebra/source/03-AT/samples/05.ptx
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 
-<example xml:id="sample-AT5"><title>AT5</title>
+<exercise xml:id="sample-AT5">
+    <title component="html">AT5</title>
+    <title component="print"><xref ref="AT5" text="global"/></title>
 <statement>
     <p>
 Let <m>V</m> be the set of all pairs of numbers <m>(x,y)</m> of real numbers together with the following operations:
@@ -128,4 +130,4 @@ Since these ordered pairs are different, the property fails to hold.
     </ol>
     </p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/03-AT/samples/06.ptx
+++ b/source/linear-algebra/source/03-AT/samples/06.ptx
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-AT6"><title>AT6</title>
+<exercise xml:id="sample-AT6">
+    <title component="html">AT6</title>
+    <title component="print"><xref ref="AT6" text="global"/></title>
     <statement>
         <p>
         <ol>
@@ -76,4 +78,4 @@ The system has (infintely many) nontrivial solutions, so we that the set of poly
     is linearly <em>dependent</em>.
         </p>
     </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/04-MX/samples/01.ptx
+++ b/source/linear-algebra/source/04-MX/samples/01.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-MX1"><title>MX1</title>
+<exercise xml:id="sample-MX1">
+    <title component="html">MX1</title>
+    <title component="print"><xref ref="MX1" text="global"/></title>
     <introduction>
         <p>
 Of the following three matrices, only two may be multiplied.
@@ -95,4 +97,4 @@ ans =
             </p>
         </solution>
     </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/04-MX/samples/02.ptx
+++ b/source/linear-algebra/source/04-MX/samples/02.ptx
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 
-<example xml:id="sample-MX2">
-      <title>MX2</title>
+<exercise xml:id="sample-MX2">
+      <title component="html">MX2</title>
+      <title component="print"><xref ref="MX2" text="global"/></title>
       <introduction>
       <p> Consider each of the following matrices. </p>
     </introduction>
@@ -90,4 +91,4 @@
             </solution>
           </task>
       </task>
-</example>
+    </exercise>

--- a/source/linear-algebra/source/04-MX/samples/03.ptx
+++ b/source/linear-algebra/source/04-MX/samples/03.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-MX3"><title>MX3</title>
+<exercise xml:id="sample-MX3">
+    <title component="html">MX3</title>
+    <title component="print"><xref ref="MX3" text="global"/></title>
     <introduction>
         <p>
             Let <m>\mathcal{B}=\setList{\begin{bmatrix}-2\\-2\\1\end{bmatrix},\begin{bmatrix}-1\\-2\\-1\end{bmatrix},\begin{bmatrix}1\\3\\2\end{bmatrix}}</m>, and <m>\vec{v}=\begin{bmatrix}1\\2\\3\end{bmatrix}</m>.
@@ -47,4 +49,4 @@
                 </p>
             </solution>
         </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/04-MX/samples/04.ptx
+++ b/source/linear-algebra/source/04-MX/samples/04.ptx
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<example xml:id="sample-MX4">
-    <title>MX4</title>
+<exercise xml:id="sample-MX4">
+    <title component="html">MX4</title>
+    <title component="print"><xref ref="MX4" text="global"/></title>
     <task>
       <statement>
         <p> Give a <m>3 \times 3</m> matrix <m>C</m> that may be used to perform the row operation <m>-5 R_1 \to R_1</m>. </p>
@@ -123,4 +124,4 @@ ans =
             </sage>
       </answer>
     </task>
-</example>
+  </exercise>

--- a/source/linear-algebra/source/05-GT/samples/01.ptx
+++ b/source/linear-algebra/source/05-GT/samples/01.ptx
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-GT1"><title>GT1</title>
+<exercise xml:id="sample-GT1">
+  <title component="html">GT1</title>
+  <title component="print"><xref ref="GT1" text="global"/></title>
     <introduction>
       <p>
 Let <m>A</m> be <em>any</em> <m>4 \times 4</m> matrix with determinant
@@ -93,4 +95,4 @@ so that <m>M=RA</m>. It follows that
           </p>
         </solution>
       </task>
-</example>
+    </exercise>

--- a/source/linear-algebra/source/05-GT/samples/02.ptx
+++ b/source/linear-algebra/source/05-GT/samples/02.ptx
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 
-<example xml:id="sample-GT2"><title>GT2</title>
+<exercise xml:id="sample-GT2">
+    <title component="html">GT2</title>
+    <title component="print"><xref ref="GT2" text="global"/></title>
 <statement>
     <p>
 Show how to compute the determinant of the matrix
@@ -80,4 +82,4 @@ the determinant to a <m>3\times 3</m> matrix and then applying a formula:
         </mrow>
     </md>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/05-GT/samples/03.ptx
+++ b/source/linear-algebra/source/05-GT/samples/03.ptx
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<example xml:id="sample-GT3">
-  <title>GT3</title>
+<exercise xml:id="sample-GT3">
+  <title component="html">GT3</title>
+  <title component="print"><xref ref="GT3" text="global"/></title>
 
   <task>
     <statement>
@@ -48,4 +49,4 @@
         </p>
     </solution>
   </task>
-</example>
+</exercise>

--- a/source/linear-algebra/source/05-GT/samples/04.ptx
+++ b/source/linear-algebra/source/05-GT/samples/04.ptx
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 
-    <example xml:id="sample-GT4"><title>GT4</title>
+    <exercise xml:id="sample-GT4">
+        <title component="html">GT4</title>
+        <title component="print"><xref ref="GT4" text="global"/></title>
 <statement>
     <p>
 Explain how to find a basis for the eigenspace associated to the eigenvalue <m>3</m> in the matrix <me>\left[\begin{array}{ccc} -7 &amp; -8 &amp; 2 \\ 8 &amp; 9 &amp; -1 \\ \frac{13}{2} &amp; 5 &amp; 2 \end{array}\right].</me>
@@ -16,4 +18,4 @@ Thus we see the kernel is <me>\setBuilder{\left[\begin{array}{c} -a \\ \frac{3}{
 which has a basis of <m>\left\{ \left[\begin{array}{c} -1 \\ \frac{3}{2} \\ 1 \end{array}\right] \right\}</m>.
     </p>
 </solution>
-</example>
+</exercise>

--- a/source/linear-algebra/source/meta/docinfo.ptx
+++ b/source/linear-algebra/source/meta/docinfo.ptx
@@ -9,7 +9,10 @@
 \usepackage{tikz-cd}
     </latex-image-preamble>
     <rename element="objectives" xml:lang="en-US">Learning Outcomes</rename>
-    <numbering><figures level="0"/></numbering>
+    <numbering>
+        <figures level="0"/>
+        <exercise level="2"/>
+    </numbering>
 <!-- Specify the default type of cross reference:           -->
     <cross-references text="type-global" />
 <brandlogo source="learning.png"/>

--- a/source/linear-algebra/source/meta/sample-exercises.ptx
+++ b/source/linear-algebra/source/meta/sample-exercises.ptx
@@ -8,33 +8,48 @@ these solutions can give you an idea of the level of detail required
 for a complete solution.
     </p>
 
-<xi:include href="../01-LE/samples/01.ptx"/>
-<xi:include href="../01-LE/samples/02.ptx"/>
-<xi:include href="../01-LE/samples/03.ptx"/>
-<xi:include href="../01-LE/samples/04.ptx"/>
+    <exercises>
+        <title><xref ref="LE"/></title>
+        <xi:include href="../01-LE/samples/01.ptx"/>
+        <xi:include href="../01-LE/samples/02.ptx"/>
+        <xi:include href="../01-LE/samples/03.ptx"/>
+        <xi:include href="../01-LE/samples/04.ptx"/>
+    </exercises>
 
-<xi:include href="../02-EV/samples/01.ptx"/>
-<xi:include href="../02-EV/samples/02.ptx"/>
-<xi:include href="../02-EV/samples/03.ptx"/>
-<xi:include href="../02-EV/samples/04.ptx"/>
-<xi:include href="../02-EV/samples/05.ptx"/>
-<xi:include href="../02-EV/samples/06.ptx"/>
-<xi:include href="../02-EV/samples/07.ptx"/>
+    <exercises>
+        <title><xref ref="EV"/></title>
+        <xi:include href="../02-EV/samples/01.ptx"/>
+        <xi:include href="../02-EV/samples/02.ptx"/>
+        <xi:include href="../02-EV/samples/03.ptx"/>
+        <xi:include href="../02-EV/samples/04.ptx"/>
+        <xi:include href="../02-EV/samples/05.ptx"/>
+        <xi:include href="../02-EV/samples/06.ptx"/>
+        <xi:include href="../02-EV/samples/07.ptx"/>
+    </exercises>
 
-<xi:include href="../03-AT/samples/01.ptx"/>
-<xi:include href="../03-AT/samples/02.ptx"/>
-<xi:include href="../03-AT/samples/03.ptx"/>
-<xi:include href="../03-AT/samples/04.ptx"/>
-<xi:include href="../03-AT/samples/05.ptx"/>
-<xi:include href="../03-AT/samples/06.ptx"/>
+    <exercises>
+        <title><xref ref="AT"/></title>
+        <xi:include href="../03-AT/samples/01.ptx"/>
+        <xi:include href="../03-AT/samples/02.ptx"/>
+        <xi:include href="../03-AT/samples/03.ptx"/>
+        <xi:include href="../03-AT/samples/04.ptx"/>
+        <xi:include href="../03-AT/samples/05.ptx"/>
+        <xi:include href="../03-AT/samples/06.ptx"/>
+    </exercises>
 
-<xi:include href="../04-MX/samples/01.ptx"/>
-<xi:include href="../04-MX/samples/02.ptx"/>
-<xi:include href="../04-MX/samples/03.ptx"/>
-<xi:include href="../04-MX/samples/04.ptx"/>
+    <exercises>
+        <title><xref ref="MX"/></title>
+        <xi:include href="../04-MX/samples/01.ptx"/>
+        <xi:include href="../04-MX/samples/02.ptx"/>
+        <xi:include href="../04-MX/samples/03.ptx"/>
+        <xi:include href="../04-MX/samples/04.ptx"/>
+    </exercises>
 
-<xi:include href="../05-GT/samples/01.ptx"/>
-<xi:include href="../05-GT/samples/02.ptx"/>
-<xi:include href="../05-GT/samples/03.ptx"/>
-<xi:include href="../05-GT/samples/04.ptx"/>
+    <exercises>
+        <title><xref ref="GT"/></title>
+        <xi:include href="../05-GT/samples/01.ptx"/>
+        <xi:include href="../05-GT/samples/02.ptx"/>
+        <xi:include href="../05-GT/samples/03.ptx"/>
+        <xi:include href="../05-GT/samples/04.ptx"/>
+    </exercises>
 </appendix>

--- a/xsl/print.xsl
+++ b/xsl/print.xsl
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--Copied from entities.ent, used to redefine exercise-->
-<!DOCTYPE xsl:stylesheet [
-    <!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::section|parent::subsection|parent::subsubsection|parent::handout">
-]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:pi="http://pretextbook.org/2020/pretext/internal">
   <xsl:import href="./core/pretext-latex.xsl" />
 

--- a/xsl/print.xsl
+++ b/xsl/print.xsl
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--Copied from entities.ent, used to redefine exercise-->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::section|parent::subsection|parent::subsubsection|parent::handout">
+]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:pi="http://pretextbook.org/2020/pretext/internal">
   <xsl:import href="./core/pretext-latex.xsl" />
 
@@ -189,5 +193,20 @@
         </xsl:when>
     </xsl:choose>
 </xsl:template>
+
+
+    <!-- Customize appearance of exercises by redefining the tcolorbox-->
+    <!-- We don't use any for now, but this does not affect exercises within exercise groups, -->
+    <!-- which have their own tcolorbox definition. -->
+    <xsl:param name="latex.preamble.late">
+        <xsl:text>% Renew tcolorbox for exercise&#xa;</xsl:text>
+        <xsl:text>\tcbset{ divisionexercisestyle/.style={bwminimalstyle, runintitlestyle, exercisespacingstyle, before skip={3 ex}, breakable, before upper app={\setparstyle} } }&#xa;</xsl:text>
+        <xsl:text>\renewtcolorbox{divisionexercise}[4]</xsl:text>
+        <xsl:text>{divisionexercisestyle, before title={}, title={\notblank{#2}{#2}{}}, after title={\notblank{#2}{\space}{}}, phantom={</xsl:text>
+        <xsl:if test="$b-pageref">
+            <xsl:text>\label{#4}</xsl:text>
+        </xsl:if>
+        <xsl:text>\hypertarget{#4}{}}, after={\notblank{#3}{\par\rule{\workspacestrutwidth}{#3}\par\vfill}{\par}}}&#xa;</xsl:text>
+    </xsl:param>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Closes #993. This changes the sample exercises to use `<exercise>` instead of `<example>`, and then customizes the typesetting of `<exercise>` in the print version.  It also removes the last references to section codes like "EV3" from the print version, sticking with chapter/section numbers.  HTML version retains the use of these codes