### PR TITLE
Remove duplicate "chapter"

### DIFF
--- a/source/linear-algebra/source/04-MX/main.ptx
+++ b/source/linear-algebra/source/04-MX/main.ptx
@@ -4,7 +4,7 @@
     <title component="print">Matrices</title>
     <introduction>
         <p>
-            In Chapter <xref ref="AT"/>, we saw that matrices are fundamentally just
+            In <xref ref="AT"/>, we saw that matrices are fundamentally just
             a representation of linear transformations (with respect to a choice of basis).
             Here, we explore the algebraic structure of the set of matrices of a given size,
             which will provide us further tools for understanding linear transformations.


### PR DESCRIPTION
Words like "Chapter" are automatically provided by `<xref>` and should not be supplied in the text.