### PR TITLE
including missing readiness outcome to EV

### DIFF
--- a/source/linear-algebra/source/02-EV/readiness.ptx
+++ b/source/linear-algebra/source/02-EV/readiness.ptx
@@ -37,6 +37,11 @@
                 </li>
             </ul></p>
         </li>
+        <li>
+            <p>
+                Use row reduction to determine the solution set of a linear system and express it in set notation. 
+            </p>
+        </li>
     </ol>
     </p>
     </assemblage>


### PR DESCRIPTION
the readiness check for EV includes having students solve linear systems using row reduction. This, of course, makes a lot of sense, but it wasn't listed as a readiness outcome. 