### PR TITLE
Remove first person singular

### DIFF
--- a/source/linear-algebra/source/01-LE/02.ptx
+++ b/source/linear-algebra/source/01-LE/02.ptx
@@ -972,7 +972,7 @@ rref(A)
         <exploration>
             <statement>
                 <p>Prove that Gauss-Jordan Elimination preserves the solution set of a system of linear equations in
-                    <m>n</m> variables. Make sure your proof includes each of the following. Just because I've used
+                    <m>n</m> variables. Make sure your proof includes each of the following. Just because we've used
                     bullet points here does not mean you should use bullet points in your proof.
             <ul>
 <li><p> Write an arbitrary system of linear equations in <m>n</m> variables. Your notation should be unambiguous.</p></li>

--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -494,21 +494,21 @@ x_2\left[\begin{array}{c}\unknown\\\unknown\\\unknown\\\unknown\end{array}\right
   <statement>
     <p>
       Are the sets
-<me>
-\setList
-{
-\left[\begin{array}{c} 1 \\ -1 \\ 2 \end{array}\right],
-\left[\begin{array}{c} 1 \\ 2 \\ 1 \end{array}\right]
-}
-</me>
-and
-<me>
-\vspan\setList
-{
-\left[\begin{array}{c} 1 \\ -1 \\ 2 \end{array}\right],
-\left[\begin{array}{c} 1 \\ 2 \\ 1 \end{array}\right]
-}
-</me>
+<md>
+  <mrow>
+    \amp \setList
+    {
+    \left[\begin{array}{c} 1 \\ -1 \\ 2 \end{array}\right],
+    \left[\begin{array}{c} 1 \\ 2 \\ 1 \end{array}\right]
+    }
+    \amp \amp \text{and} \amp \amp
+    \vspan\setList
+    {
+    \left[\begin{array}{c} 1 \\ -1 \\ 2 \end{array}\right],
+    \left[\begin{array}{c} 1 \\ 2 \\ 1 \end{array}\right]
+    }
+  </mrow>
+</md>
       equal or nonequal to each other?
       <ol marker="A." cols="2">
         <li><p>Equal</p></li>

--- a/source/linear-algebra/source/02-EV/01.ptx
+++ b/source/linear-algebra/source/02-EV/01.ptx
@@ -621,7 +621,7 @@ in <m>\IR^3</m>.
             <statement>
                 <p> Suppose <m>S = \{\vec{v_1},\ldots, \vec{v_n}\}</m> is a set of vectors. Show that <m>\vec{v_0}</m> is a linear combination of members of <m>S</m>, if an only if there are a set of scalars <m>\{c_0,c_1,\ldots, c_n\}</m> such that <m>\vec{z} = c_0\vec{v_0} + \cdots + c_n\vec{v_n}.</m>
 
-We can do this in a few parts. I've used bullets here to indicate all that needs to be done. This is an "if and only if" proof, so it needs two parts. 
+We can do this in a few parts. We've used bullets here to indicate all that needs to be done. This is an "if and only if" proof, so it needs two parts. 
 <ul> <li>First, assume that <m>\vec{0} = c_0\vec{v_0} + \cdots + c_n\vec{v_n}</m> has a solution, with <m>c_0 \neq 0</m>. Show that <m>\vec{v_0}</m> is a linear combination of elements of <m>S</m>.</li>
     <li>Next, assume that <m>\vec{v_0}</m> is a linear combination of elements of <m>S</m>. Can you find the appropriate <m>\{c_0,c_1,\ldots, c_n\}</m> to make the equation <m>\vec{z} = c_0\vec{v_0} + \cdots + c_n\vec{v_n}</m> true?</li>
     <li>In either of your proofs above, does the case when <m>\vec{v_0} = \vec{z}</m> change your thinking? Explain why or why not.</li>


### PR DESCRIPTION
It is a little jarring to read the first person singular when we use first person plural everywhere else.