### PR TITLE
Use words

### DIFF
--- a/source/linear-algebra/source/02-EV/02.ptx
+++ b/source/linear-algebra/source/02-EV/02.ptx
@@ -162,7 +162,7 @@ since <m>\IR^1=\setBuilder{cx}{c\in\IR}</m>.
   At least <m>m</m> vectors are required to span <m>\IR^m</m>.
         </p>
         <figure>
-            <caption>Failed attempts to span <m>\IR^m</m> by fewer than vectors</caption>
+            <caption>Failed attempts to span <m>\IR^m</m> by fewer than <m>m</m> vectors</caption>
         <image width="75%" xml:id="EV2-image-span-r3">
             <latex-image>
   \begin{tikzpicture}[scale=0.5]

--- a/source/linear-algebra/source/02-EV/02.ptx
+++ b/source/linear-algebra/source/02-EV/02.ptx
@@ -162,7 +162,7 @@ since <m>\IR^1=\setBuilder{cx}{c\in\IR}</m>.
   At least <m>m</m> vectors are required to span <m>\IR^m</m>.
         </p>
         <figure>
-            <caption>Failed attempts to span <m>\IR^m</m> by <m>&lt;m</m> vectors</caption>
+            <caption>Failed attempts to span <m>\IR^m</m> by fewer than vectors</caption>
         <image width="75%" xml:id="EV2-image-span-r3">
             <latex-image>
   \begin{tikzpicture}[scale=0.5]


### PR DESCRIPTION
Relational operators should not be used outside of properly formatted relations.