### PR TITLE
Hacky fix for #989

### DIFF
--- a/publication/publication-619.ptx
+++ b/publication/publication-619.ptx
@@ -106,7 +106,7 @@
     javascript, etc).  -->
     <calculator model="none" activecode="none" />
     <!-- Set the base URL of where the online version is hosted to have links in other formats -->
-    <baseurl href="https://tbil.org"/>
+    <baseurl href="https://library.tbil.org/2026/linear-algebra/"/>
     <!-- Control behavior of online WeBWorK, per type: -->
     <webwork
       inline="dynamic"


### PR DESCRIPTION
This fixes the `<baseurl>` in the publication file that is used for the printed Linear Algebra version.  However, it is a bit hacky as if we want to publish another print book we would have to duplicate this publication file and change just the baseurl.  A better way to do this will be in #1036, but the CLI doesn't seem to handle the `<xi:include>`s correctly right now.