### PR TITLE
Add LCCN to copyright page

### DIFF
--- a/assets/frontmatter/copyright-page.tex
+++ b/assets/frontmatter/copyright-page.tex
@@ -18,7 +18,8 @@ This work is licensed under the Creative Commons Attribution-Non-Commercial-Shar
 \noindent 2026 Edition
 \vskip 1ex
 
- \noindent ISBN: 978-1-958469-38-5
+ \noindent ISBN 978-1-958469-38-5 \\
+ \noindent LCCN 2026947355
 
 \vskip 3em
 


### PR DESCRIPTION
Adds the Library of Congress Control Number to the copyright page of the print LA book, below the ISBN.