### PR TITLE
Fix inadvertently commented out outcome (TR4)

### DIFF
--- a/source/precalculus/exercises/bank.xml
+++ b/source/precalculus/exercises/bank.xml
@@ -348,7 +348,6 @@
             </description>
         </outcome>
         
-        <!-- 
         <outcome>
             <title>Special Right Triangles</title>
             <slug>TR4</slug>
@@ -357,7 +356,6 @@
                Find exact values of trigonometric functions of special angles (30, 45, and 60). 
             </description>
         </outcome> 
-        -->
 
         <outcome>
             <title>The Unit Circle</title>

--- a/source/precalculus/exercises/bank.xml
+++ b/source/precalculus/exercises/bank.xml
@@ -349,7 +349,7 @@
         </outcome>
         
         <outcome>
-            <title>Special Right Triangles</title>
+            <title>Special  Right Triangles</title>
             <slug>TR4</slug>
             <path>outcomes/TR/TR4</path>
             <description>


### PR DESCRIPTION
Apparently the TR4 exercises were not showing up because they are commented out of the bank, but it looks like there are exercises there so this will include them upon rebuild.